### PR TITLE
Event system improvements, pt. 2

### DIFF
--- a/OpenNefia.Content.Tests/EntityGen/EntityGen_Tests.cs
+++ b/OpenNefia.Content.Tests/EntityGen/EntityGen_Tests.cs
@@ -95,7 +95,7 @@ entities:
             {
                 base.Initialize();
 
-                SubscribeLocalEvent<EntityGenTestComponent, EntityGeneratedEvent>(OnGen);
+                SubscribeComponent<EntityGenTestComponent, EntityGeneratedEvent>(OnGen);
             }
 
             private void OnGen(EntityUid uid, EntityGenTestComponent component, ref EntityGeneratedEvent args)

--- a/OpenNefia.Content.Tests/RandomAreas/AreaRandomGenSystem_Tests.cs
+++ b/OpenNefia.Content.Tests/RandomAreas/AreaRandomGenSystem_Tests.cs
@@ -105,8 +105,8 @@ namespace OpenNefia.Content.Tests.Areas
 
             public override void Initialize()
             {
-                SubscribeLocalEvent<TestRandomAreaComponent, RandomAreaCheckIsActiveEvent>(HandleIsActive);
-                SubscribeLocalEvent<GenerateRandomAreaEvent>(GenerateRandomArea);
+                SubscribeComponent<TestRandomAreaComponent, RandomAreaCheckIsActiveEvent>(HandleIsActive);
+                SubscribeBroadcast<GenerateRandomAreaEvent>(GenerateRandomArea);
             }
 
             private void HandleIsActive(EntityUid uid, TestRandomAreaComponent component, RandomAreaCheckIsActiveEvent args)

--- a/OpenNefia.Content/Areas/AreaStaticFloorsSystem.cs
+++ b/OpenNefia.Content/Areas/AreaStaticFloorsSystem.cs
@@ -19,7 +19,7 @@ namespace OpenNefia.Content.Areas
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<AreaStaticFloorsComponent, AreaFloorGenerateEvent>(OnAreaFloorGenerate);
+            SubscribeComponent<AreaStaticFloorsComponent, AreaFloorGenerateEvent>(OnAreaFloorGenerate);
         }
 
         private void OnAreaFloorGenerate(EntityUid areaEntity, AreaStaticFloorsComponent areaStaticFloors, AreaFloorGenerateEvent args)

--- a/OpenNefia.Content/Arena/AreaArenaSystem.cs
+++ b/OpenNefia.Content/Arena/AreaArenaSystem.cs
@@ -29,7 +29,7 @@ namespace OpenNefia.Content.Arena
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<AreaArenaComponent, AreaMapInitializeEvent>(CheckArenaRenew);
+            SubscribeComponent<AreaArenaComponent, AreaMapInitializeEvent>(CheckArenaRenew);
         }
 
         private void CheckArenaRenew(EntityUid uid, AreaArenaComponent component, AreaMapInitializeEvent args)

--- a/OpenNefia.Content/CharaMake/CharaMakeCharaSheetLayer.cs
+++ b/OpenNefia.Content/CharaMake/CharaMakeCharaSheetLayer.cs
@@ -232,7 +232,7 @@ namespace OpenNefia.Content.CharaMake
                 Sounds.Play(Sound.Skill);
 
                 var ev = new NewPlayerIncarnatedEvent(_playerEntity);
-                EntityManager.EventBus.RaiseLocalEvent(_playerEntity, ev);
+                EntityManager.EventBus.RaiseEvent(_playerEntity, ev);
 
                 if (!EntityManager.IsAlive(_playerEntity))
                 {

--- a/OpenNefia.Content/CharaMake/NewPlayerIncarnationSystem.cs
+++ b/OpenNefia.Content/CharaMake/NewPlayerIncarnationSystem.cs
@@ -31,7 +31,7 @@ namespace OpenNefia.Content.CharaMake
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<PlayerComponent, NewPlayerIncarnatedEvent>(HandleNewPlayerIncarnated);
+            SubscribeComponent<PlayerComponent, NewPlayerIncarnatedEvent>(HandleNewPlayerIncarnated);
         }
 
         private void HandleNewPlayerIncarnated(EntityUid uid, PlayerComponent player, NewPlayerIncarnatedEvent args)

--- a/OpenNefia.Content/Charas/CharaSystem.cs
+++ b/OpenNefia.Content/Charas/CharaSystem.cs
@@ -49,7 +49,7 @@ namespace OpenNefia.Content.Charas
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<CharaComponent, EntityGeneratedEvent>(HandleGenerated, priority: EventPriorities.Highest);
+            SubscribeComponent<CharaComponent, EntityGeneratedEvent>(HandleGenerated, priority: EventPriorities.Highest);
         }
 
         private void HandleGenerated(EntityUid uid, CharaComponent chara, ref EntityGeneratedEvent args)

--- a/OpenNefia.Content/DisplayName/DisplayNameSystem.cs
+++ b/OpenNefia.Content/DisplayName/DisplayNameSystem.cs
@@ -39,7 +39,7 @@ namespace OpenNefia.Content.DisplayName
         public string GetBaseName(EntityUid uid)
         {
             var ev = new GetBaseNameEventArgs();
-            RaiseLocalEvent(uid, ref ev);
+            RaiseEvent(uid, ref ev);
             return ev.BaseName;
         }
 
@@ -47,7 +47,7 @@ namespace OpenNefia.Content.DisplayName
         {
             var baseName = GetBaseName(uid);
             var ev = new GetDisplayNameEventArgs() { Name = baseName };
-            RaiseLocalEvent(uid, ref ev);
+            RaiseEvent(uid, ref ev);
             return ev.Name;
         }
     }

--- a/OpenNefia.Content/DisplayName/DisplayNameSystem.cs
+++ b/OpenNefia.Content/DisplayName/DisplayNameSystem.cs
@@ -16,7 +16,7 @@ namespace OpenNefia.Content.DisplayName
         {
             base.Initialize();
 
-            SubscribeLocalEvent<MetaDataComponent, GetBaseNameEventArgs>(GetDefaultBaseName, priority: EventPriorities.Highest);
+            SubscribeComponent<MetaDataComponent, GetBaseNameEventArgs>(GetDefaultBaseName, priority: EventPriorities.Highest);
         }
 
         private string GetFallbackName(EntityUid uid)

--- a/OpenNefia.Content/DisplayName/ItemNameSystem.cs
+++ b/OpenNefia.Content/DisplayName/ItemNameSystem.cs
@@ -17,7 +17,7 @@ namespace OpenNefia.Content.DisplayName
         {
             base.Initialize();
 
-            SubscribeLocalEvent<ItemComponent, GetItemNameEvent>(BasicName, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<ItemComponent, GetItemNameEvent>(BasicName, priority: EventPriorities.VeryHigh);
         }
 
         public void BasicName(EntityUid uid, ItemComponent component, ref GetItemNameEvent args)

--- a/OpenNefia.Content/DisplayName/ObjectDisplayNameSystem.cs
+++ b/OpenNefia.Content/DisplayName/ObjectDisplayNameSystem.cs
@@ -12,8 +12,8 @@ namespace OpenNefia.Content.DisplayName
         {
             base.Initialize();
 
-            SubscribeLocalEvent<CharaComponent, GetDisplayNameEventArgs>(GetCharaName, priority: EventPriorities.Highest);
-            SubscribeLocalEvent<ItemComponent, GetDisplayNameEventArgs>(GetItemName, priority: EventPriorities.Highest);
+            SubscribeComponent<CharaComponent, GetDisplayNameEventArgs>(GetCharaName, priority: EventPriorities.Highest);
+            SubscribeComponent<ItemComponent, GetDisplayNameEventArgs>(GetItemName, priority: EventPriorities.Highest);
         }
 
         public void GetCharaName(EntityUid uid, CharaComponent component, ref GetDisplayNameEventArgs args)
@@ -26,7 +26,7 @@ namespace OpenNefia.Content.DisplayName
         public void GetItemName(EntityUid uid, ItemComponent component, ref GetDisplayNameEventArgs args)
         {
             var ev = new GetItemNameEvent();
-            EntityManager.EventBus.RaiseLocalEvent(uid, ref ev);
+            EntityManager.EventBus.RaiseEvent(uid, ref ev);
             args.Name = ev.ItemName;
         }
     }

--- a/OpenNefia.Content/EntityGen/EntityGenSystem.cs
+++ b/OpenNefia.Content/EntityGen/EntityGenSystem.cs
@@ -50,7 +50,7 @@ namespace OpenNefia.Content.EntityGen
         {
             _mapLoader.OnBlueprintEntityStartup += HandleBlueprintEntityStartup;
 
-            SubscribeLocalEvent<SpatialComponent, EntityCloneFinishedEventArgs>(HandleClone, priority: EventPriorities.VeryLow);
+            SubscribeComponent<SpatialComponent, EntityCloneFinishedEventArgs>(HandleClone, priority: EventPriorities.VeryLow);
         }
 
         public void FireGeneratedEvent(EntityUid entity)

--- a/OpenNefia.Content/EntityGen/EntityGenSystem.cs
+++ b/OpenNefia.Content/EntityGen/EntityGenSystem.cs
@@ -57,7 +57,7 @@ namespace OpenNefia.Content.EntityGen
         {
             // TODO: Check if generated has already been fired for this entity.
             var ev = new EntityGeneratedEvent();
-            RaiseLocalEvent(entity, ref ev);
+            RaiseEvent(entity, ref ev);
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace OpenNefia.Content.EntityGen
 
             args ??= EntityGenArgSet.Make();
             var ev = new EntityBeingGeneratedEvent(args);
-            RaiseLocalEvent(ent, ref ev);
+            RaiseEvent(ent, ref ev);
 
             FireGeneratedEvent(ent);
 

--- a/OpenNefia.Content/EntityGen/EntityGenSystem.cs
+++ b/OpenNefia.Content/EntityGen/EntityGenSystem.cs
@@ -50,7 +50,7 @@ namespace OpenNefia.Content.EntityGen
         {
             _mapLoader.OnBlueprintEntityStartup += HandleBlueprintEntityStartup;
 
-            SubscribeComponent<SpatialComponent, EntityCloneFinishedEventArgs>(HandleClone, priority: EventPriorities.VeryLow);
+            SubscribeEntity<EntityCloneFinishedEventArgs>(HandleClone, priority: EventPriorities.VeryLow);
         }
 
         public void FireGeneratedEvent(EntityUid entity)
@@ -71,7 +71,7 @@ namespace OpenNefia.Content.EntityGen
         /// <summary>
         /// Runs entity generation events for all cloned entities.
         /// </summary>
-        private void HandleClone(EntityUid entity, SpatialComponent component, EntityCloneFinishedEventArgs args)
+        private void HandleClone(EntityUid entity, EntityCloneFinishedEventArgs args)
         {
             FireGeneratedEvent(entity);
         }

--- a/OpenNefia.Content/EquipSlots/EquipSlotsSystem.cs
+++ b/OpenNefia.Content/EquipSlots/EquipSlotsSystem.cs
@@ -40,10 +40,10 @@ namespace OpenNefia.Content.EquipSlots
                 return;
 
             var gotUnequippedEvent = new GotUnequippedEvent(uid, args.Entity, equipSlot);
-            RaiseLocalEvent(args.Entity, gotUnequippedEvent);
+            RaiseEvent(args.Entity, gotUnequippedEvent);
 
             var unequippedEvent = new DidUnequipEvent(uid, args.Entity, equipSlot);
-            RaiseLocalEvent(uid, unequippedEvent);
+            RaiseEvent(uid, unequippedEvent);
         }
 
         private void OnEntInserted(EntityUid uid, EquipSlotsComponent equipSlots, EntInsertedIntoContainerMessage args)
@@ -52,10 +52,10 @@ namespace OpenNefia.Content.EquipSlots
                 return;
 
             var gotEquippedEvent = new GotEquippedEvent(uid, args.Entity, equipSlot);
-            RaiseLocalEvent(args.Entity, gotEquippedEvent);
+            RaiseEvent(args.Entity, gotEquippedEvent);
 
             var equippedEvent = new DidEquipEvent(uid, args.Entity, equipSlot);
-            RaiseLocalEvent(uid, equippedEvent);
+            RaiseEvent(uid, equippedEvent);
         }
 
         public bool TryEquip(EntityUid uid, EntityUid itemUid, EquipSlotInstance equipSlot,
@@ -143,7 +143,7 @@ namespace OpenNefia.Content.EquipSlots
                 return false;
 
             var attemptEvent = new IsEquippingAttemptEvent(actor, target, itemUid, equipSlot);
-            RaiseLocalEvent(target, attemptEvent);
+            RaiseEvent(target, attemptEvent);
             if (attemptEvent.Cancelled)
             {
                 reason = attemptEvent.Reason ?? reason;
@@ -154,7 +154,7 @@ namespace OpenNefia.Content.EquipSlots
             {
                 //reuse the event. this is gucci, right?
                 attemptEvent.Reason = null;
-                RaiseLocalEvent(actor, attemptEvent);
+                RaiseEvent(actor, attemptEvent);
                 if (attemptEvent.Cancelled)
                 {
                     reason = attemptEvent.Reason ?? reason;
@@ -163,7 +163,7 @@ namespace OpenNefia.Content.EquipSlots
             }
 
             var itemAttemptEvent = new BeingEquippedAttemptEvent(actor, target, itemUid, equipSlot);
-            RaiseLocalEvent(itemUid, itemAttemptEvent);
+            RaiseEvent(itemUid, itemAttemptEvent);
             if (itemAttemptEvent.Cancelled)
             {
                 reason = itemAttemptEvent.Reason ?? reason;
@@ -303,7 +303,7 @@ namespace OpenNefia.Content.EquipSlots
             var itemUid = containerSlot.ContainedEntity.Value;
 
             var attemptEvent = new IsUnequippingAttemptEvent(actor, target, itemUid, equipSlot);
-            RaiseLocalEvent(target, attemptEvent);
+            RaiseEvent(target, attemptEvent);
             if (attemptEvent.Cancelled)
             {
                 reason = attemptEvent.Reason ?? reason;
@@ -314,7 +314,7 @@ namespace OpenNefia.Content.EquipSlots
             {
                 //reuse the event. this is gucci, right?
                 attemptEvent.Reason = null;
-                RaiseLocalEvent(actor, attemptEvent);
+                RaiseEvent(actor, attemptEvent);
                 if (attemptEvent.Cancelled)
                 {
                     reason = attemptEvent.Reason ?? reason;
@@ -323,7 +323,7 @@ namespace OpenNefia.Content.EquipSlots
             }
 
             var itemAttemptEvent = new BeingUnequippedAttemptEvent(actor, target, itemUid, equipSlot);
-            RaiseLocalEvent(itemUid, itemAttemptEvent);
+            RaiseEvent(itemUid, itemAttemptEvent);
             if (itemAttemptEvent.Cancelled)
             {
                 reason = attemptEvent.Reason ?? reason;

--- a/OpenNefia.Content/EquipSlots/EquipSlotsSystem.cs
+++ b/OpenNefia.Content/EquipSlots/EquipSlotsSystem.cs
@@ -30,8 +30,8 @@ namespace OpenNefia.Content.EquipSlots
         public override void Initialize()
         {
             //these events ensure that the client also gets its proper events raised when getting its containerstate updated
-            SubscribeLocalEvent<EquipSlotsComponent, EntInsertedIntoContainerMessage>(OnEntInserted, priority: EventPriorities.Low);
-            SubscribeLocalEvent<EquipSlotsComponent, EntRemovedFromContainerMessage>(OnEntRemoved, priority: EventPriorities.Low);
+            SubscribeComponent<EquipSlotsComponent, EntInsertedIntoContainerMessage>(OnEntInserted, priority: EventPriorities.Low);
+            SubscribeComponent<EquipSlotsComponent, EntRemovedFromContainerMessage>(OnEntRemoved, priority: EventPriorities.Low);
         }
 
         private void OnEntRemoved(EntityUid uid, EquipSlotsComponent equipSlots, EntRemovedFromContainerMessage args)

--- a/OpenNefia.Content/Equipment/EquipBonusSystem.cs
+++ b/OpenNefia.Content/Equipment/EquipBonusSystem.cs
@@ -13,8 +13,8 @@ namespace OpenNefia.Content.Equipment
     {
         public override void Initialize()
         {
-            SubscribeLocalEvent<EquipBonusComponent, EntityRefreshEvent>(OnRefresh, priority: EventPriorities.High);
-            SubscribeLocalEvent<EquipBonusComponent, ApplyEquipmentToEquipperEvent>(OnApplyToEquipper, priority: EventPriorities.High);
+            SubscribeComponent<EquipBonusComponent, EntityRefreshEvent>(OnRefresh, priority: EventPriorities.High);
+            SubscribeComponent<EquipBonusComponent, ApplyEquipmentToEquipperEvent>(OnApplyToEquipper, priority: EventPriorities.High);
         }
 
         private void OnRefresh(EntityUid uid, EquipBonusComponent equipBonus, ref EntityRefreshEvent args)

--- a/OpenNefia.Content/Equipment/EquipmentLayer.cs
+++ b/OpenNefia.Content/Equipment/EquipmentLayer.cs
@@ -345,7 +345,7 @@ namespace OpenNefia.Content.Equipment
 
                 // Display messages relating to curse state, weapon suitability, etc.
                 var ev = new GotEquippedInMenuEvent(_equipee, _equipTarget, equipSlot);
-                _entityManager.EventBus.RaiseLocalEvent(splitItem, ev);
+                _entityManager.EventBus.RaiseEvent(splitItem, ev);
                 OnEquipped?.Invoke(ev);
 
                 UpdateFromEquipTarget();

--- a/OpenNefia.Content/Equipment/EquipmentSystem.cs
+++ b/OpenNefia.Content/Equipment/EquipmentSystem.cs
@@ -73,7 +73,7 @@ namespace OpenNefia.Content.Equipment
                     if (EntityManager.IsAlive(equipment))
                     {
                         var ev = new ApplyEquipmentToEquipperEvent(equipper);
-                        RaiseLocalEvent(equipment.Value, ref ev);
+                        RaiseEvent(equipment.Value, ref ev);
                     }
                 }
             }

--- a/OpenNefia.Content/Equipment/EquipmentSystem.cs
+++ b/OpenNefia.Content/Equipment/EquipmentSystem.cs
@@ -33,12 +33,12 @@ namespace OpenNefia.Content.Equipment
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<EquipmentComponent, GotEquippedEvent>(HandleGotEquipped);
-            SubscribeLocalEvent<EquipmentComponent, GotUnequippedEvent>(HandleGotUnequipped);
+            SubscribeComponent<EquipmentComponent, GotEquippedEvent>(HandleGotEquipped);
+            SubscribeComponent<EquipmentComponent, GotUnequippedEvent>(HandleGotUnequipped);
 
-            SubscribeLocalEvent<EquipSlotsComponent, DidEquipEvent>(HandleDidEquip);
-            SubscribeLocalEvent<EquipSlotsComponent, DidUnequipEvent>(HandleDidUnequip);
-            SubscribeLocalEvent<EquipSlotsComponent, EntityRefreshEvent>(HandleRefresh, priority: EventPriorities.High);
+            SubscribeComponent<EquipSlotsComponent, DidEquipEvent>(HandleDidEquip);
+            SubscribeComponent<EquipSlotsComponent, DidUnequipEvent>(HandleDidUnequip);
+            SubscribeComponent<EquipSlotsComponent, EntityRefreshEvent>(HandleRefresh, priority: EventPriorities.High);
         }
 
         #region Event Handlers

--- a/OpenNefia.Content/Factions/FactionSystem.cs
+++ b/OpenNefia.Content/Factions/FactionSystem.cs
@@ -25,7 +25,7 @@ namespace OpenNefia.Content.Factions
         public Relation GetRelationTowards(EntityUid us, EntityUid them)
         {
             var ev = new CalculateRelationEventArgs(them);
-            RaiseLocalEvent(us, ref ev);
+            RaiseEvent(us, ref ev);
             return ev.Relation;
         }
 

--- a/OpenNefia.Content/Factions/FactionSystem.cs
+++ b/OpenNefia.Content/Factions/FactionSystem.cs
@@ -18,7 +18,7 @@ namespace OpenNefia.Content.Factions
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<FactionComponent, CalculateRelationEventArgs>(HandleCalculateRelation, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<FactionComponent, CalculateRelationEventArgs>(HandleCalculateRelation, priority: EventPriorities.VeryHigh);
         }
 
         /// <inheritdoc/>

--- a/OpenNefia.Content/Fame/FameSystem.cs
+++ b/OpenNefia.Content/Fame/FameSystem.cs
@@ -12,7 +12,7 @@ namespace OpenNefia.Content.Fame
     {
         public override void Initialize()
         {
-            SubscribeLocalEvent<FameComponent, EntityRefreshEvent>(HandleRefresh);
+            SubscribeComponent<FameComponent, EntityRefreshEvent>(HandleRefresh);
         }
 
         private void HandleRefresh(EntityUid uid, FameComponent fameComp, ref EntityRefreshEvent args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/CombatSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/CombatSystem.cs
@@ -106,7 +106,7 @@ namespace OpenNefia.Content.GameObjects
         public TurnResult? MeleeAttack(EntityUid attacker, EntityUid target)
         {
             var ev = new GetMeleeWeaponsEvent();
-            RaiseLocalEvent(attacker, ev);
+            RaiseEvent(attacker, ev);
 
             if (ev.Weapons.Count > 0)
             {
@@ -156,7 +156,7 @@ namespace OpenNefia.Content.GameObjects
                 Weapon = weapon,
                 AttackCount = attackCount
             };
-            RaiseLocalEvent(attacker, ev);
+            RaiseEvent(attacker, ev);
         }
     }
 

--- a/OpenNefia.Content/GameObjects/EntitySystems/CombatSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/CombatSystem.cs
@@ -31,8 +31,8 @@ namespace OpenNefia.Content.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<MoveableComponent, CollideWithEventArgs>(HandleCollideWith, priority: EventPriorities.Low);
-            SubscribeLocalEvent<SkillsComponent, PhysicalAttackEventArgs>(HandlePhysicalAttackMain);
+            SubscribeComponent<MoveableComponent, CollideWithEventArgs>(HandleCollideWith, priority: EventPriorities.Low);
+            SubscribeComponent<SkillsComponent, PhysicalAttackEventArgs>(HandlePhysicalAttackMain);
         }
 
         private void HandlePhysicalAttackMain(EntityUid uid, SkillsComponent skills, PhysicalAttackEventArgs args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/ContentStackSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/ContentStackSystem.cs
@@ -15,10 +15,10 @@ namespace OpenNefia.Content.GameObjects
         [Dependency] private readonly IMessagesManager _mes = default!;
         public override void Initialize()
         {
-            SubscribeComponent<SpatialComponent, EntityStackedEvent>(HandleStacked);
+            SubscribeEntity<EntityStackedEvent>(HandleStacked);
         }
 
-        private void HandleStacked(EntityUid uid, SpatialComponent component, ref EntityStackedEvent args)
+        private void HandleStacked(EntityUid uid, ref EntityStackedEvent args)
         {
             if (args.ShowMessage)
             {

--- a/OpenNefia.Content/GameObjects/EntitySystems/ContentStackSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/ContentStackSystem.cs
@@ -15,7 +15,7 @@ namespace OpenNefia.Content.GameObjects
         [Dependency] private readonly IMessagesManager _mes = default!;
         public override void Initialize()
         {
-            SubscribeLocalEvent<SpatialComponent, EntityStackedEvent>(HandleStacked);
+            SubscribeComponent<SpatialComponent, EntityStackedEvent>(HandleStacked);
         }
 
         private void HandleStacked(EntityUid uid, SpatialComponent component, ref EntityStackedEvent args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/CurseStateSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/CurseStateSystem.cs
@@ -16,7 +16,7 @@ namespace OpenNefia.Content.GameObjects.EntitySystems
         [Dependency] private readonly IMessagesManager _mes = default!;
         public override void Initialize()
         {
-            SubscribeLocalEvent<CurseStateComponent, GotEquippedInMenuEvent>(OnEquippedInMenu, priority: EventPriorities.High);
+            SubscribeComponent<CurseStateComponent, GotEquippedInMenuEvent>(OnEquippedInMenu, priority: EventPriorities.High);
         }
 
         private void OnEquippedInMenu(EntityUid item, CurseStateComponent component, GotEquippedInMenuEvent args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/DoorSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/DoorSystem.cs
@@ -24,11 +24,11 @@ namespace OpenNefia.Content.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<DoorComponent, GetVerbsEventArgs>(HandleGetVerbs);
-            SubscribeLocalEvent<ExecuteVerbEventArgs>(HandleExecuteVerb);
-            SubscribeLocalEvent<DoorComponent, DoCloseEventArgs>(HandleClose);
-            SubscribeLocalEvent<DoorComponent, EntityMapInitEvent>(HandleInitialize);
-            SubscribeLocalEvent<DoorComponent, WasCollidedWithEventArgs>(HandleCollidedWith);
+            SubscribeComponent<DoorComponent, GetVerbsEventArgs>(HandleGetVerbs);
+            SubscribeBroadcast<ExecuteVerbEventArgs>(HandleExecuteVerb);
+            SubscribeComponent<DoorComponent, DoCloseEventArgs>(HandleClose);
+            SubscribeComponent<DoorComponent, EntityMapInitEvent>(HandleInitialize);
+            SubscribeComponent<DoorComponent, WasCollidedWithEventArgs>(HandleCollidedWith);
         }
 
         private void HandleGetVerbs(EntityUid uid, DoorComponent component, GetVerbsEventArgs args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/DrinkableSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/DrinkableSystem.cs
@@ -24,12 +24,12 @@ namespace OpenNefia.Content.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<DrinkableComponent, GetVerbsEventArgs>(HandleGetVerbs);
-            SubscribeLocalEvent<ExecuteVerbEventArgs>(HandleExecuteVerb);
-            SubscribeLocalEvent<DrinkableComponent, DoDrinkEventArgs>(HandleDoDrink);
-            SubscribeLocalEvent<DrinkableComponent, ThrownEntityImpactedOtherEvent>(HandleImpactOther);
-            SubscribeLocalEvent<DrinkableComponent, ThrownEntityImpactedGroundEvent>(HandleImpactGround);
-            SubscribeLocalEvent<PotionPuddleComponent, EntitySteppedOnEvent>(HandlePotionPuddleSteppedOn);
+            SubscribeComponent<DrinkableComponent, GetVerbsEventArgs>(HandleGetVerbs);
+            SubscribeBroadcast<ExecuteVerbEventArgs>(HandleExecuteVerb);
+            SubscribeComponent<DrinkableComponent, DoDrinkEventArgs>(HandleDoDrink);
+            SubscribeComponent<DrinkableComponent, ThrownEntityImpactedOtherEvent>(HandleImpactOther);
+            SubscribeComponent<DrinkableComponent, ThrownEntityImpactedGroundEvent>(HandleImpactGround);
+            SubscribeComponent<PotionPuddleComponent, EntitySteppedOnEvent>(HandlePotionPuddleSteppedOn);
         }
 
         private void HandleGetVerbs(EntityUid potion, DrinkableComponent drinkableComp, GetVerbsEventArgs args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/EdibleSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/EdibleSystem.cs
@@ -21,10 +21,10 @@ namespace OpenNefia.Content.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<EdibleComponent, GetVerbsEventArgs>(HandleGetVerbs);
-            SubscribeLocalEvent<ExecuteVerbEventArgs>(HandleExecuteVerb);
-            SubscribeLocalEvent<EdibleComponent, DoEatEventArgs>(HandleDoEat);
-            SubscribeLocalEvent<EdibleComponent, ThrownEntityImpactedOtherEvent>(HandleImpactOther);
+            SubscribeComponent<EdibleComponent, GetVerbsEventArgs>(HandleGetVerbs);
+            SubscribeBroadcast<ExecuteVerbEventArgs>(HandleExecuteVerb);
+            SubscribeComponent<EdibleComponent, DoEatEventArgs>(HandleDoEat);
+            SubscribeComponent<EdibleComponent, ThrownEntityImpactedOtherEvent>(HandleImpactOther);
         }
 
         private void HandleGetVerbs(EntityUid potion, EdibleComponent edibleComp, GetVerbsEventArgs args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/EntityMemorySystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/EntityMemorySystem.cs
@@ -18,8 +18,8 @@ namespace OpenNefia.Content.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<ChipComponent, GetMapObjectMemoryEventArgs>(ProduceSpriteMemory, priority: EventPriorities.VeryHigh);
-            SubscribeLocalEvent<CharaComponent, GetMapObjectMemoryEventArgs>(HideWhenOutOfSight, priority: EventPriorities.High);
+            SubscribeComponent<ChipComponent, GetMapObjectMemoryEventArgs>(ProduceSpriteMemory, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<CharaComponent, GetMapObjectMemoryEventArgs>(HideWhenOutOfSight, priority: EventPriorities.High);
         }
 
         private void HideWhenOutOfSight(EntityUid uid, CharaComponent component, GetMapObjectMemoryEventArgs args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/EntityMemorySystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/EntityMemorySystem.cs
@@ -43,7 +43,7 @@ namespace OpenNefia.Content.GameObjects
         {
             var memory = new MapObjectMemory();
             var ev = new GetMapObjectMemoryEventArgs(memory);
-            RaiseLocalEvent(entity, ev);
+            RaiseEvent(entity, ev);
             return memory;
         }
     }

--- a/OpenNefia.Content/GameObjects/EntitySystems/ItemDescriptionSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/ItemDescriptionSystem.cs
@@ -14,8 +14,8 @@ namespace OpenNefia.Content.GameObjects.EntitySystems
     {
         public override void Initialize()
         {
-            SubscribeLocalEvent<ItemComponent, GetItemDescriptionEventArgs>(GetDescItem, priority: EventPriorities.VeryHigh);
-            SubscribeLocalEvent<ItemDescriptionComponent, GetItemDescriptionEventArgs>(GetDescItemDesc, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<ItemComponent, GetItemDescriptionEventArgs>(GetDescItem, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<ItemDescriptionComponent, GetItemDescriptionEventArgs>(GetDescItemDesc, priority: EventPriorities.VeryHigh);
         }
 
         private void GetDescItem(EntityUid uid, ItemComponent item, GetItemDescriptionEventArgs args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/ItemDescriptionSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/ItemDescriptionSystem.cs
@@ -71,7 +71,7 @@ namespace OpenNefia.Content.GameObjects.EntitySystems
         public void GetItemDescription(EntityUid entity, IList<ItemDescriptionEntry> entries)
         {
             var ev = new GetItemDescriptionEventArgs(entries);
-            RaiseLocalEvent(entity, ev);
+            RaiseEvent(entity, ev);
          
             if (entries.Count == 0)
             {

--- a/OpenNefia.Content/GameObjects/EntitySystems/PlayerMovementSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/PlayerMovementSystem.cs
@@ -22,9 +22,9 @@ namespace OpenNefia.Content.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<MoveableComponent, BeforeMoveEventArgs>(HandleBeforeMove, priority: EventPriorities.High);
-            SubscribeLocalEvent<PlayerComponent, BeforeMoveEventArgs>(HandleBeforeMovePlayer, priority: EventPriorities.High);
-            SubscribeLocalEvent<PlayerComponent, AfterMoveEventArgs>(HandleAfterMovePlayer, priority: EventPriorities.High);
+            SubscribeComponent<MoveableComponent, BeforeMoveEventArgs>(HandleBeforeMove, priority: EventPriorities.High);
+            SubscribeComponent<PlayerComponent, BeforeMoveEventArgs>(HandleBeforeMovePlayer, priority: EventPriorities.High);
+            SubscribeComponent<PlayerComponent, AfterMoveEventArgs>(HandleAfterMovePlayer, priority: EventPriorities.High);
         }
 
         private void HandleBeforeMovePlayer(EntityUid uid, PlayerComponent player, BeforeMoveEventArgs args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/PregnantSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/PregnantSystem.cs
@@ -26,8 +26,8 @@ namespace OpenNefia.Content.GameObjects
         {
             base.Initialize();
 
-            SubscribeLocalEvent<CharaComponent, ImpregnateEvent>(HandleImpregnate);
-            SubscribeLocalEvent<PregnantComponent, TurnStartEvent>(DoAlienBirth);
+            SubscribeComponent<CharaComponent, ImpregnateEvent>(HandleImpregnate);
+            SubscribeComponent<PregnantComponent, TurnStartEvent>(DoAlienBirth);
         }
 
         public void HandleImpregnate(EntityUid uid, CharaComponent component, ImpregnateEvent args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/RefreshSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/RefreshSystem.cs
@@ -22,7 +22,7 @@ namespace OpenNefia.Content.GameObjects
         public void Refresh(EntityUid entity)
         {
             var ev = new EntityRefreshEvent();
-            RaiseLocalEvent(entity, ref ev);
+            RaiseEvent(entity, ref ev);
         }
 
         private void OnMapInit(EntityUid uid, MetaDataComponent component, ref EntityMapInitEvent args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/RefreshSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/RefreshSystem.cs
@@ -16,7 +16,7 @@ namespace OpenNefia.Content.GameObjects
     {
         public override void Initialize()
         {
-            SubscribeComponent<MetaDataComponent, EntityMapInitEvent>(OnMapInit, priority: EventPriorities.VeryLow);
+            SubscribeEntity<EntityMapInitEvent>(OnMapInit, priority: EventPriorities.VeryLow);
         }
 
         public void Refresh(EntityUid entity)
@@ -25,7 +25,7 @@ namespace OpenNefia.Content.GameObjects
             RaiseEvent(entity, ref ev);
         }
 
-        private void OnMapInit(EntityUid uid, MetaDataComponent component, ref EntityMapInitEvent args)
+        private void OnMapInit(EntityUid uid, ref EntityMapInitEvent args)
         {
             Refresh(uid);
         }

--- a/OpenNefia.Content/GameObjects/EntitySystems/RefreshSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/RefreshSystem.cs
@@ -16,7 +16,7 @@ namespace OpenNefia.Content.GameObjects
     {
         public override void Initialize()
         {
-            SubscribeLocalEvent<MetaDataComponent, EntityMapInitEvent>(OnMapInit, priority: EventPriorities.VeryLow);
+            SubscribeComponent<MetaDataComponent, EntityMapInitEvent>(OnMapInit, priority: EventPriorities.VeryLow);
         }
 
         public void Refresh(EntityUid entity)

--- a/OpenNefia.Content/GameObjects/EntitySystems/StairsSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/StairsSystem.cs
@@ -23,9 +23,9 @@ namespace OpenNefia.Content.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<StairsComponent, GetVerbsEventArgs>(HandleGetVerbs);
-            SubscribeLocalEvent<ExecuteVerbEventArgs>(HandleExecuteVerb);
-            SubscribeLocalEvent<StairsComponent, UseStairsEventArgs>(HandleUseStairs);
+            SubscribeComponent<StairsComponent, GetVerbsEventArgs>(HandleGetVerbs);
+            SubscribeBroadcast<ExecuteVerbEventArgs>(HandleExecuteVerb);
+            SubscribeComponent<StairsComponent, UseStairsEventArgs>(HandleUseStairs);
         }
 
         private void HandleGetVerbs(EntityUid uid, StairsComponent component, GetVerbsEventArgs args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/SteppedOnSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/SteppedOnSystem.cs
@@ -10,7 +10,7 @@ namespace OpenNefia.Content.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<MoveableComponent, AfterMoveEventArgs>(HandleAfterMove);
+            SubscribeComponent<MoveableComponent, AfterMoveEventArgs>(HandleAfterMove);
         }
 
         private void HandleAfterMove(EntityUid uid, MoveableComponent moveable, AfterMoveEventArgs args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/SteppedOnSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/SteppedOnSystem.cs
@@ -29,7 +29,7 @@ namespace OpenNefia.Content.GameObjects
             foreach (var steppedSpatial in _lookup.GetLiveEntitiesAtCoords(spatial.MapPosition).ToList())
             {
                 var ev = new EntitySteppedOnEvent(stepper, spatial.MapPosition);
-                RaiseLocalEvent(steppedSpatial.Owner, ev);
+                RaiseEvent(steppedSpatial.Owner, ev);
 
                 if (!EntityManager.IsAlive(stepper))
                     break;

--- a/OpenNefia.Content/GameObjects/EntitySystems/TargetTextSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/TargetTextSystem.cs
@@ -32,7 +32,7 @@ namespace OpenNefia.Content.GameObjects
             foreach (var spatial in _lookup.GetLiveEntitiesAtCoords(targetPos))
             {
                 var ev = new GetTargetTextEventArgs(onlooker, visibleOnly);
-                RaiseLocalEvent(spatial.Owner, ev);
+                RaiseEvent(spatial.Owner, ev);
                 foreach (var line in ev.TargetTexts)
                 {
                     sb.AppendLine(line);

--- a/OpenNefia.Content/GameObjects/EntitySystems/TargetTextSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/TargetTextSystem.cs
@@ -16,7 +16,7 @@ namespace OpenNefia.Content.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<CharaComponent, GetTargetTextEventArgs>(HandleTargetTextChara);
+            SubscribeComponent<CharaComponent, GetTargetTextEventArgs>(HandleTargetTextChara);
         }
 
         public bool GetTargetText(EntityUid onlooker, MapCoordinates targetPos, out string text, bool visibleOnly)

--- a/OpenNefia.Content/GameObjects/EntitySystems/ThrowableSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/ThrowableSystem.cs
@@ -105,7 +105,7 @@ namespace OpenNefia.Content.GameObjects
             _mes.Display(Loc.GetString("Elona.Throwable.Throws", ("entity", source), ("item", throwing)));
 
             var ev = new EntityThrownEventArgs(source, coords);
-            RaiseLocalEvent(throwing, ev);
+            RaiseEvent(throwing, ev);
             return true;
         }
 

--- a/OpenNefia.Content/GameObjects/EntitySystems/ThrowableSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/ThrowableSystem.cs
@@ -25,11 +25,11 @@ namespace OpenNefia.Content.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<ThrowableComponent, GetVerbsEventArgs>(HandleGetVerbs);
-            SubscribeLocalEvent<ExecuteVerbEventArgs>(HandleExecuteVerb);
-            SubscribeLocalEvent<ChipComponent, EntityThrownEventArgs>(ShowThrownChipRenderable, priority: EventPriorities.VeryHigh);
-            SubscribeLocalEvent<ThrowableComponent, EntityThrownEventArgs>(HandleEntityThrown);
-            SubscribeLocalEvent<CharaComponent, HitByThrownEntityEventArgs>(HandleCharaHitByThrown);
+            SubscribeComponent<ThrowableComponent, GetVerbsEventArgs>(HandleGetVerbs);
+            SubscribeBroadcast<ExecuteVerbEventArgs>(HandleExecuteVerb);
+            SubscribeComponent<ChipComponent, EntityThrownEventArgs>(ShowThrownChipRenderable, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<ThrowableComponent, EntityThrownEventArgs>(HandleEntityThrown);
+            SubscribeComponent<CharaComponent, HitByThrownEntityEventArgs>(HandleCharaHitByThrown);
         }
 
         private void HandleCharaHitByThrown(EntityUid uid, CharaComponent component, HitByThrownEntityEventArgs args)

--- a/OpenNefia.Content/GameObjects/EntitySystems/WorldMapFieldsSystem.cs
+++ b/OpenNefia.Content/GameObjects/EntitySystems/WorldMapFieldsSystem.cs
@@ -21,8 +21,8 @@ namespace OpenNefia.Content.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<WorldMapFieldsComponent, GetVerbsEventArgs>(HandleGetVerbs);
-            SubscribeLocalEvent<ExecuteVerbEventArgs>(HandleExecuteVerb);
+            SubscribeComponent<WorldMapFieldsComponent, GetVerbsEventArgs>(HandleGetVerbs);
+            SubscribeBroadcast<ExecuteVerbEventArgs>(HandleExecuteVerb);
         }
 
         private void HandleGetVerbs(EntityUid uid, WorldMapFieldsComponent component, GetVerbsEventArgs args)

--- a/OpenNefia.Content/GameObjects/Pickable/PickableSystem.cs
+++ b/OpenNefia.Content/GameObjects/Pickable/PickableSystem.cs
@@ -34,10 +34,10 @@ namespace OpenNefia.Content.GameObjects.Pickable
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<PickableComponent, GetVerbsEventArgs>(HandleGetVerbs);
-            SubscribeLocalEvent<ExecuteVerbEventArgs>(HandleExecuteVerb);
-            SubscribeLocalEvent<PickableComponent, DoPickUpEventArgs>(HandleDoPickUp);
-            SubscribeLocalEvent<PickableComponent, DoDropEventArgs>(HandleDoDrop);
+            SubscribeComponent<PickableComponent, GetVerbsEventArgs>(HandleGetVerbs);
+            SubscribeBroadcast<ExecuteVerbEventArgs>(HandleExecuteVerb);
+            SubscribeComponent<PickableComponent, DoPickUpEventArgs>(HandleDoPickUp);
+            SubscribeComponent<PickableComponent, DoDropEventArgs>(HandleDoDrop);
         }
 
         private void HandleGetVerbs(EntityUid uid, PickableComponent pickable, GetVerbsEventArgs args)

--- a/OpenNefia.Content/Karma/KarmaSystem.cs
+++ b/OpenNefia.Content/Karma/KarmaSystem.cs
@@ -13,7 +13,7 @@ namespace OpenNefia.Content.Fame
     {
         public override void Initialize()
         {
-            SubscribeLocalEvent<KarmaComponent, EntityRefreshEvent>(HandleRefresh);
+            SubscribeComponent<KarmaComponent, EntityRefreshEvent>(HandleRefresh);
         }
 
         private void HandleRefresh(EntityUid uid, KarmaComponent karmaComp, ref EntityRefreshEvent args)

--- a/OpenNefia.Content/MapVisibility/MapVisibilitySystem.cs
+++ b/OpenNefia.Content/MapVisibility/MapVisibilitySystem.cs
@@ -16,8 +16,8 @@ namespace OpenNefia.Content.MapVisibility
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<MapCreatedEvent>(HandleMapCreated, priority: EventPriorities.Highest);
-            SubscribeLocalEvent<MapVisibilityComponent, RefreshMapVisibilityEvent>(RefreshVisibility, priority: EventPriorities.High);
+            SubscribeBroadcast<MapCreatedEvent>(HandleMapCreated, priority: EventPriorities.Highest);
+            SubscribeComponent<MapVisibilityComponent, RefreshMapVisibilityEvent>(RefreshVisibility, priority: EventPriorities.High);
         }
 
         private void HandleMapCreated(MapCreatedEvent ev)

--- a/OpenNefia.Content/Maps/Debris/MapDebrisSystem.cs
+++ b/OpenNefia.Content/Maps/Debris/MapDebrisSystem.cs
@@ -24,7 +24,7 @@ namespace OpenNefia.Content.Maps
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<MapCreatedEvent>(HandleMapCreated, priority: EventPriorities.Highest);
+            SubscribeBroadcast<MapCreatedEvent>(HandleMapCreated, priority: EventPriorities.Highest);
         }
 
         public const int MaxBlood = 6;

--- a/OpenNefia.Content/Maps/Entrances/MapTransferSystem.Events.cs
+++ b/OpenNefia.Content/Maps/Entrances/MapTransferSystem.Events.cs
@@ -184,11 +184,11 @@ namespace OpenNefia.Content.Maps
             UpdateQuests(map);
 
             var ev = new MapInitializeEvent(map, loadType);
-            RaiseLocalEvent(map.MapEntityUid, ev);
+            RaiseEvent(map.MapEntityUid, ev);
             if (_areaManager.TryGetAreaOfMap(map.Id, out var area))
             {
                 var areaEv = new AreaMapInitializeEvent(map, loadType);
-                RaiseLocalEvent(area.AreaEntityUid, areaEv);
+                RaiseEvent(area.AreaEntityUid, areaEv);
             }
         }
 
@@ -256,7 +256,7 @@ namespace OpenNefia.Content.Maps
             }
 
             var ev = new MapRenewMajorEvent(isFirstRenewal);
-            RaiseLocalEvent(map.MapEntityUid, ev);
+            RaiseEvent(map.MapEntityUid, ev);
         }
 
         private void RenewMinor(IMap map, MapCommonComponent common)
@@ -281,7 +281,7 @@ namespace OpenNefia.Content.Maps
             Logger.InfoS("map.renew", $"Running minor renewal for map {map}. ({renewSteps} steps)");
 
             var ev = new MapRenewMinorEvent(renewSteps);
-            RaiseLocalEvent(map.MapEntityUid, ev);
+            RaiseEvent(map.MapEntityUid, ev);
         }
 
         private void RecalculateMaxCharas(IMap map)
@@ -412,11 +412,11 @@ namespace OpenNefia.Content.Maps
             RevealFog(map);
 
             var ev = new MapEnterEvent(map, loadType);
-            RaiseLocalEvent(map.MapEntityUid, ev);
+            RaiseEvent(map.MapEntityUid, ev);
             if (_areaManager.TryGetAreaOfMap(map.Id, out var area))
             {
                 var areaEv = new AreaMapEnterEvent(map, loadType);
-                RaiseLocalEvent(area.AreaEntityUid, areaEv);
+                RaiseEvent(area.AreaEntityUid, areaEv);
             }
 
             UpdateDeepestFloor(map);

--- a/OpenNefia.Content/Maps/Entrances/MapTransferSystem.cs
+++ b/OpenNefia.Content/Maps/Entrances/MapTransferSystem.cs
@@ -31,9 +31,9 @@ namespace OpenNefia.Content.Maps
         
         public override void Initialize()
         {
-            SubscribeLocalEvent<PlayerComponent, ExitingMapFromEdgesEventArgs>(HandleExitMapFromEdges, priority: EventPriorities.Low);
-            SubscribeLocalEvent<MapComponent, ActiveMapChangedEvent>(HandleActiveMapChanged, priority: EventPriorities.VeryHigh);
-            SubscribeLocalEvent<MapComponent, MapLeaveEventArgs>(HandleLeaveMap, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<PlayerComponent, ExitingMapFromEdgesEventArgs>(HandleExitMapFromEdges, priority: EventPriorities.Low);
+            SubscribeComponent<MapComponent, ActiveMapChangedEvent>(HandleActiveMapChanged, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<MapComponent, MapLeaveEventArgs>(HandleLeaveMap, priority: EventPriorities.VeryHigh);
         }
 
         public void DoMapTransfer(SpatialComponent spatial, IMap map, EntityCoordinates newCoords, MapLoadType loadType)

--- a/OpenNefia.Content/Maps/Entrances/MapTransferSystem.cs
+++ b/OpenNefia.Content/Maps/Entrances/MapTransferSystem.cs
@@ -66,7 +66,7 @@ namespace OpenNefia.Content.Maps
             if (oldMap != null)
             {
                 var evLeave = new MapLeaveEventArgs(map, oldMap);
-                RaiseLocalEvent(oldMap.MapEntityUid, evLeave);
+                RaiseEvent(oldMap.MapEntityUid, evLeave);
             }
 
             _mapManager.SetActiveMap(map.Id, loadType);

--- a/OpenNefia.Content/Maps/Entrances/WorldMapEntranceSystem.cs
+++ b/OpenNefia.Content/Maps/Entrances/WorldMapEntranceSystem.cs
@@ -17,9 +17,9 @@ namespace OpenNefia.Content.Maps
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<WorldMapEntranceComponent, GetVerbsEventArgs>(HandleGetVerbs);
-            SubscribeLocalEvent<ExecuteVerbEventArgs>(HandleExecuteVerb);
-            SubscribeLocalEvent<WorldMapEntranceComponent, UseWorldMapEntranceEvent>(HandleUseWorldMapEntrance);
+            SubscribeComponent<WorldMapEntranceComponent, GetVerbsEventArgs>(HandleGetVerbs);
+            SubscribeBroadcast<ExecuteVerbEventArgs>(HandleExecuteVerb);
+            SubscribeComponent<WorldMapEntranceComponent, UseWorldMapEntranceEvent>(HandleUseWorldMapEntrance);
         }
 
         private void HandleGetVerbs(EntityUid uid, WorldMapEntranceComponent component, GetVerbsEventArgs args)

--- a/OpenNefia.Content/Maps/MapCharaGenSystem.cs
+++ b/OpenNefia.Content/Maps/MapCharaGenSystem.cs
@@ -18,7 +18,7 @@ namespace OpenNefia.Content.Maps
     {
         public override void Initialize()
         {
-            SubscribeLocalEvent<MapCharaGenComponent, GetCharaFilterEvent>(SetDefaultFilter);
+            SubscribeComponent<MapCharaGenComponent, GetCharaFilterEvent>(SetDefaultFilter);
         }
 
         private void SetDefaultFilter(EntityUid uid, MapCharaGenComponent component, ref GetCharaFilterEvent args)

--- a/OpenNefia.Content/Maps/MapCommonSystem.cs
+++ b/OpenNefia.Content/Maps/MapCommonSystem.cs
@@ -13,7 +13,7 @@ namespace OpenNefia.Content.Maps
     {
         public override void Initialize()
         {
-            SubscribeLocalEvent<MapCreatedEvent>(AddRequiredComponents, priority: EventPriorities.Highest);
+            SubscribeBroadcast<MapCreatedEvent>(AddRequiredComponents, priority: EventPriorities.Highest);
         }
 
         private void AddRequiredComponents(MapCreatedEvent args)

--- a/OpenNefia.Content/Maps/MapPlacementSystem.cs
+++ b/OpenNefia.Content/Maps/MapPlacementSystem.cs
@@ -295,7 +295,7 @@ namespace OpenNefia.Content.Maps
             charaComp.Liveness = liveness;
 
             var ev = new CharaPlaceFailureEvent(entity);
-            RaiseLocalEvent(entity, ev);
+            RaiseEvent(entity, ev);
         }
     }
 

--- a/OpenNefia.Content/Nefia/AreaNefiaSystem.cs
+++ b/OpenNefia.Content/Nefia/AreaNefiaSystem.cs
@@ -160,7 +160,7 @@ namespace OpenNefia.Content.Nefia
                 return;
 
             var ev = new NefiaFloorGenerateEvent(args.Area, args.FloorId, args.PreviousCoords);
-            RaiseLocalEvent(uid, ev);
+            RaiseEvent(uid, ev);
 
             if (ev.Handled)
             {

--- a/OpenNefia.Content/Nefia/AreaNefiaSystem.cs
+++ b/OpenNefia.Content/Nefia/AreaNefiaSystem.cs
@@ -54,13 +54,13 @@ namespace OpenNefia.Content.Nefia
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<AreaNefiaComponent, AreaEnteredEvent>(OnNefiaAreaEntered, priority: EventPriorities.High);
-            SubscribeLocalEvent<AreaNefiaComponent, AreaFloorGenerateEvent>(OnNefiaFloorGenerate, priority: EventPriorities.High);
-            SubscribeLocalEvent<AreaNefiaComponent, AreaGeneratedEvent>(OnNefiaGenerated, priority: EventPriorities.High);
-            SubscribeLocalEvent<AreaNefiaComponent, RandomAreaCheckIsActiveEvent>(OnCheckIsActive, priority: EventPriorities.High);
-            SubscribeLocalEvent<AreaNefiaComponent, AreaMapInitializeEvent>(SpawnNefiaBoss);
+            SubscribeComponent<AreaNefiaComponent, AreaEnteredEvent>(OnNefiaAreaEntered, priority: EventPriorities.High);
+            SubscribeComponent<AreaNefiaComponent, AreaFloorGenerateEvent>(OnNefiaFloorGenerate, priority: EventPriorities.High);
+            SubscribeComponent<AreaNefiaComponent, AreaGeneratedEvent>(OnNefiaGenerated, priority: EventPriorities.High);
+            SubscribeComponent<AreaNefiaComponent, RandomAreaCheckIsActiveEvent>(OnCheckIsActive, priority: EventPriorities.High);
+            SubscribeComponent<AreaNefiaComponent, AreaMapInitializeEvent>(SpawnNefiaBoss);
             
-            SubscribeLocalEvent<GenerateRandomAreaEvent>(GenerateRandomNefia, priority: EventPriorities.VeryLow);
+            SubscribeBroadcast<GenerateRandomAreaEvent>(GenerateRandomNefia, priority: EventPriorities.VeryLow);
         }
 
         private void OnNefiaAreaEntered(EntityUid uid, AreaNefiaComponent areaNefia, AreaEnteredEvent args)

--- a/OpenNefia.Content/Nefia/Gen/VanillaNefiaGenSystem.cs
+++ b/OpenNefia.Content/Nefia/Gen/VanillaNefiaGenSystem.cs
@@ -50,10 +50,10 @@ namespace OpenNefia.Content.Nefia
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<NefiaVanillaComponent, NefiaFloorGenerateEvent>(OnNefiaFloorGenerate, priority: EventPriorities.High);
-            SubscribeLocalEvent<NefiaVanillaComponent, GenerateNefiaFloorParamsEvent>(SetupBaseParams, priority: EventPriorities.VeryHigh);
-            SubscribeLocalEvent<NefiaVanillaComponent, GenerateNefiaFloorAttemptEvent>(GenerateFloorAttempt, priority: EventPriorities.High);
-            SubscribeLocalEvent<NefiaVanillaComponent, AfterGenerateNefiaFloorEvent>(FinalizeNefia, priority: EventPriorities.High);
+            SubscribeComponent<NefiaVanillaComponent, NefiaFloorGenerateEvent>(OnNefiaFloorGenerate, priority: EventPriorities.High);
+            SubscribeComponent<NefiaVanillaComponent, GenerateNefiaFloorParamsEvent>(SetupBaseParams, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<NefiaVanillaComponent, GenerateNefiaFloorAttemptEvent>(GenerateFloorAttempt, priority: EventPriorities.High);
+            SubscribeComponent<NefiaVanillaComponent, AfterGenerateNefiaFloorEvent>(FinalizeNefia, priority: EventPriorities.High);
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace OpenNefia.Content.Nefia
                 return false;
 
             var ev = new AfterGenerateNefiaFloorEvent(area, map, data, floorNumber);
-            EntityManager.EventBus.RaiseLocalEvent(area.AreaEntityUid, ev);
+            EntityManager.EventBus.RaiseEvent(area.AreaEntityUid, ev);
 
             return true;
         }
@@ -118,10 +118,10 @@ namespace OpenNefia.Content.Nefia
                 data.Get<BaseNefiaGenParams>().MapSize = (width, height);
 
                 var paramsEv = new GenerateNefiaFloorParamsEvent(area, mapId, data, floorNumber, i);
-                EntityManager.EventBus.RaiseLocalEvent(area.AreaEntityUid, paramsEv);
+                EntityManager.EventBus.RaiseEvent(area.AreaEntityUid, paramsEv);
 
                 var genEv = new GenerateNefiaFloorAttemptEvent(area, mapId, data, floorNumber, i);
-                EntityManager.EventBus.RaiseLocalEvent(area.AreaEntityUid, genEv);
+                EntityManager.EventBus.RaiseEvent(area.AreaEntityUid, genEv);
 
                 if (genEv.Handled)
                 {

--- a/OpenNefia.Content/PCCs/PCCSystem.cs
+++ b/OpenNefia.Content/PCCs/PCCSystem.cs
@@ -44,8 +44,8 @@ namespace OpenNefia.Content.PCCs
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<PCCComponent, ComponentStartup>(OnComponentStartup);
-            SubscribeLocalEvent<PCCComponent, ComponentShutdown>(OnComponentShutdown);
+            SubscribeComponent<PCCComponent, ComponentStartup>(OnComponentStartup);
+            SubscribeComponent<PCCComponent, ComponentShutdown>(OnComponentShutdown);
         }
 
         private void OnComponentStartup(EntityUid uid, PCCComponent pccComp, ComponentStartup args)

--- a/OpenNefia.Content/Parties/PartySystem.cs
+++ b/OpenNefia.Content/Parties/PartySystem.cs
@@ -220,7 +220,7 @@ namespace OpenNefia.Content.Parties
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<EntityDeletedEvent>(HandleEntityDeleted, priority: EventPriorities.VeryHigh);
+            SubscribeBroadcast<EntityDeletedEvent>(HandleEntityDeleted, priority: EventPriorities.VeryHigh);
         }
 
         private void HandleEntityDeleted(EntityDeletedEvent ev)

--- a/OpenNefia.Content/Parties/PartySystem.cs
+++ b/OpenNefia.Content/Parties/PartySystem.cs
@@ -380,7 +380,7 @@ namespace OpenNefia.Content.Parties
             }
 
             var ev = new CharaRecruitedAsAllyEvent(leader, noMessage);
-            RaiseLocalEvent(ally, ev);
+            RaiseEvent(ally, ev);
 
             return true;
         }

--- a/OpenNefia.Content/Pot/PotSystem.cs
+++ b/OpenNefia.Content/Pot/PotSystem.cs
@@ -38,7 +38,7 @@ namespace OpenNefia.Content.Pot
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<PotComponent, WasCollidedWithEventArgs>(HandleCollidedWith);
+            SubscribeComponent<PotComponent, WasCollidedWithEventArgs>(HandleCollidedWith);
         }
 
         private void HandleCollidedWith(EntityUid uid, PotComponent component, WasCollidedWithEventArgs args)

--- a/OpenNefia.Content/Qualities/QualitySystem.cs
+++ b/OpenNefia.Content/Qualities/QualitySystem.cs
@@ -13,7 +13,7 @@ namespace OpenNefia.Content.Qualities
     {
         public override void Initialize()
         {
-            SubscribeLocalEvent<QualityComponent, GetBaseNameEventArgs>(AddQualityBrackets);
+            SubscribeComponent<QualityComponent, GetBaseNameEventArgs>(AddQualityBrackets);
         }
 
         private void AddQualityBrackets(EntityUid uid, QualityComponent quality, ref GetBaseNameEventArgs args)

--- a/OpenNefia.Content/RandomAreas/AreaRandomGenSystem.cs
+++ b/OpenNefia.Content/RandomAreas/AreaRandomGenSystem.cs
@@ -43,7 +43,7 @@ namespace OpenNefia.Content.RandomAreas
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<MapRandomAreaManagerComponent, MapEnterEvent>(OnMapEnter, priority: EventPriorities.High);
+            SubscribeComponent<MapRandomAreaManagerComponent, MapEnterEvent>(OnMapEnter, priority: EventPriorities.High);
         }
 
         private void OnMapEnter(EntityUid mapEnt, MapRandomAreaManagerComponent mapRandomAreas, MapEnterEvent args)

--- a/OpenNefia.Content/RandomAreas/AreaRandomGenSystem.cs
+++ b/OpenNefia.Content/RandomAreas/AreaRandomGenSystem.cs
@@ -90,7 +90,7 @@ namespace OpenNefia.Content.RandomAreas
                 if (mapCoords != null)
                 {
                     var ev = new GenerateRandomAreaEvent(mapCoords.Value);
-                    RaiseLocalEvent(map.MapEntityUid, ev);
+                    RaiseEvent(map.MapEntityUid, ev);
                     if (ev.ResultArea != null)
                     {
                         _areaEntrances.CreateAreaEntrance(ev.ResultArea, ev.RandomAreaCoords);
@@ -216,7 +216,7 @@ namespace OpenNefia.Content.RandomAreas
         {
             var ev = new RandomAreaCheckIsActiveEvent();
             ev.IsActive = false;
-            RaiseLocalEvent(area.AreaEntityUid, ev);
+            RaiseEvent(area.AreaEntityUid, ev);
             return ev.IsActive;
         }
 

--- a/OpenNefia.Content/RandomGen/CharaGenSystem.cs
+++ b/OpenNefia.Content/RandomGen/CharaGenSystem.cs
@@ -176,7 +176,7 @@ namespace OpenNefia.Content.RandomGen
         public CharaFilter GenerateCharaFilter(IMap map)
         {
             var ev = new GetCharaFilterEvent(map);
-            RaiseLocalEvent(map.MapEntityUid, ref ev);
+            RaiseEvent(map.MapEntityUid, ref ev);
             return ev.CharaFilter;
         }
 

--- a/OpenNefia.Content/RandomSite/RandomSiteSystem.cs
+++ b/OpenNefia.Content/RandomSite/RandomSiteSystem.cs
@@ -28,7 +28,7 @@ namespace OpenNefia.Content.RandomSite
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<MapRenewMajorEvent>(SpawnRandomSites);
+            SubscribeBroadcast<MapRenewMajorEvent>(SpawnRandomSites);
         }
 
         private void SpawnRandomSites(MapRenewMajorEvent ev)

--- a/OpenNefia.Content/Religion/ReligionSystem.cs
+++ b/OpenNefia.Content/Religion/ReligionSystem.cs
@@ -76,10 +76,10 @@ namespace OpenNefia.Content.Religion
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<ReligionComponent, OnJoinFaithEvent>(OnJoinFaith);
-            SubscribeLocalEvent<ReligionComponent, OnLeaveFaithEvent>(OnLeaveFaith);
-            SubscribeLocalEvent<ReligionComponent, EntityBeingGeneratedEvent>(SetRandomGod);
-            SubscribeLocalEvent<ReligionComponent, EntityRefreshEvent>(ApplyBlessings);
+            SubscribeComponent<ReligionComponent, OnJoinFaithEvent>(OnJoinFaith);
+            SubscribeComponent<ReligionComponent, OnLeaveFaithEvent>(OnLeaveFaith);
+            SubscribeComponent<ReligionComponent, EntityBeingGeneratedEvent>(SetRandomGod);
+            SubscribeComponent<ReligionComponent, EntityRefreshEvent>(ApplyBlessings);
         }
 
         private void SetRandomGod(EntityUid uid, ReligionComponent component, ref EntityBeingGeneratedEvent args)

--- a/OpenNefia.Content/Religion/ReligionSystem.cs
+++ b/OpenNefia.Content/Religion/ReligionSystem.cs
@@ -279,7 +279,7 @@ namespace OpenNefia.Content.Religion
             if (religion.GodID != null)
             {
                 var ev = new OnLeaveFaithEvent(religion.GodID.Value);
-                RaiseLocalEvent(target, ev);
+                RaiseEvent(target, ev);
             }
 
             religion.GodID = newGodID;
@@ -296,7 +296,7 @@ namespace OpenNefia.Content.Religion
                 GodSays(newGodID.Value, "Elona.GodStartBelievingIn");
 
                 var ev = new OnJoinFaithEvent(newGodID.Value);
-                RaiseLocalEvent(target, ev);
+                RaiseEvent(target, ev);
             }
 
             _refresh.Refresh(target);
@@ -456,7 +456,7 @@ namespace OpenNefia.Content.Religion
         public int CalculateItemPietyValue(EntityUid item)
         {
             var ev = new CalculateItemPietyValueEvent(item);
-            RaiseLocalEvent(item, ev);
+            RaiseEvent(item, ev);
             return ev.ResultPietyValue;
         }
 

--- a/OpenNefia.Content/Resists/ResistsSystem.cs
+++ b/OpenNefia.Content/Resists/ResistsSystem.cs
@@ -38,7 +38,7 @@ namespace OpenNefia.Content.Resists
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<ResistsComponent, EntityRefreshEvent>(HandleRefresh, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<ResistsComponent, EntityRefreshEvent>(HandleRefresh, priority: EventPriorities.VeryHigh);
         }
 
         private void HandleRefresh(EntityUid uid, ResistsComponent resists, ref EntityRefreshEvent args)

--- a/OpenNefia.Content/Skills/SkillAdjustsSystem.cs
+++ b/OpenNefia.Content/Skills/SkillAdjustsSystem.cs
@@ -19,7 +19,7 @@ namespace OpenNefia.Content.Skills
     {
         public override void Initialize()
         {
-            SubscribeLocalEvent<SkillAdjustsComponent, EntityRefreshEvent>(OnRefresh);
+            SubscribeComponent<SkillAdjustsComponent, EntityRefreshEvent>(OnRefresh);
         }
 
         private void OnRefresh(EntityUid entity, SkillAdjustsComponent skillAdj, ref EntityRefreshEvent args)

--- a/OpenNefia.Content/Skills/SkillsSystem.Leveling.cs
+++ b/OpenNefia.Content/Skills/SkillsSystem.Leveling.cs
@@ -85,7 +85,7 @@ namespace OpenNefia.Content.Skills
             var levelDelta = ProcSkillLeveling(uid, skillProto, skill, newExp);
 
             var ev = new SkillExpGainedEvent(skillProto, expGained, expGained, levelDelta);
-            RaiseLocalEvent(uid, ref ev);
+            RaiseEvent(uid, ref ev);
         }
 
         /// <inheritdoc/>
@@ -161,7 +161,7 @@ namespace OpenNefia.Content.Skills
             var levelDelta = ProcSkillLeveling(uid, skillProto, skill, newExp);
 
             var ev = new SkillExpGainedEvent(skillProto, baseExpGained, actualExpGained, levelDelta);
-            RaiseLocalEvent(uid, ref ev);
+            RaiseEvent(uid, ref ev);
 
             // <<<<<<<< shade2/module.hsp:349 	#defcfunc calcFame int c,int per ..
         }

--- a/OpenNefia.Content/Skills/SkillsSystem.cs
+++ b/OpenNefia.Content/Skills/SkillsSystem.cs
@@ -82,8 +82,8 @@ namespace OpenNefia.Content.Skills
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<SkillsComponent, EntityRefreshEvent>(HandleRefresh, priority: EventPriorities.VeryHigh);
-            SubscribeLocalEvent<SkillsComponent, EntityGeneratedEvent>(HandleGenerated, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<SkillsComponent, EntityRefreshEvent>(HandleRefresh, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<SkillsComponent, EntityGeneratedEvent>(HandleGenerated, priority: EventPriorities.VeryHigh);
         }
 
         private void HandleGenerated(EntityUid uid, SkillsComponent component, ref EntityGeneratedEvent args)

--- a/OpenNefia.Content/TitleScreen/MainTitleLogic.cs
+++ b/OpenNefia.Content/TitleScreen/MainTitleLogic.cs
@@ -190,7 +190,7 @@ namespace OpenNefia.Content.TitleScreen
             _mapManager.SetActiveMap(map.Id);
 
             var ev = new NewGameStartedEventArgs();
-            _entityManager.EventBus.RaiseLocalEvent(_gameSessionManager.Player, ev);
+            _entityManager.EventBus.RaiseEvent(_gameSessionManager.Player, ev);
 
             _mapManager.RefreshVisibility(map);
 
@@ -230,7 +230,7 @@ namespace OpenNefia.Content.TitleScreen
             if (!isNewSave)
             {
                 var ev = new GameLoadedEventArgs();
-                _entityManager.EventBus.RaiseLocalEvent(_gameSessionManager.Player, ev);
+                _entityManager.EventBus.RaiseEvent(_gameSessionManager.Player, ev);
             }
 
             _uiManager.Query(_fieldLayer);
@@ -239,7 +239,7 @@ namespace OpenNefia.Content.TitleScreen
 
             // TODO this shouldn't target an entity?
             var evCleanedUp = new GameCleanedUpEventArgs();
-            _entityManager.EventBus.RaiseLocalEvent(_gameSessionManager.Player, evCleanedUp);
+            _entityManager.EventBus.RaiseEvent(_gameSessionManager.Player, evCleanedUp);
         }
     }
 

--- a/OpenNefia.Content/TurnOrder/TurnOrderSystem.cs
+++ b/OpenNefia.Content/TurnOrder/TurnOrderSystem.cs
@@ -89,7 +89,7 @@ namespace OpenNefia.Content.TurnOrder
             _mapManager.OnActiveMapChanged += OnActiveMapChanged;
             _saveGameSerializer.OnGameLoaded += OnGameLoaded;
 
-            SubscribeLocalEvent<MapTurnOrderComponent, ActiveMapChangedEvent>(HandleMapChangedTurnOrder, priority: EventPriorities.VeryHigh);
+            SubscribeComponent<MapTurnOrderComponent, ActiveMapChangedEvent>(HandleMapChangedTurnOrder, priority: EventPriorities.VeryHigh);
         }
 
         #region Event Handlers

--- a/OpenNefia.Content/TurnOrder/TurnOrderSystem.cs
+++ b/OpenNefia.Content/TurnOrder/TurnOrderSystem.cs
@@ -434,7 +434,7 @@ namespace OpenNefia.Content.TurnOrder
             _field.RefreshScreen();
 
             var ev = new PlayerTurnStartedEvent();
-            RaiseLocalEvent(turnOrder.Owner, ref ev);
+            RaiseEvent(turnOrder.Owner, ref ev);
             if (ev.Handled)
             {
                 return ev.TurnResult.ToTurnOrderState();
@@ -447,7 +447,7 @@ namespace OpenNefia.Content.TurnOrder
         private TurnOrderState HandleNPCTurn(TurnOrderComponent turnOrder)
         {
             var ev = new NPCTurnStartedEvent();
-            RaiseLocalEvent(turnOrder.Owner, ref ev);
+            RaiseEvent(turnOrder.Owner, ref ev);
             return ev.TurnResult.ToTurnOrderState();
         }
 
@@ -459,7 +459,7 @@ namespace OpenNefia.Content.TurnOrder
             }
 
             var ev = new EntityTurnEndingEventArgs();
-            RaiseLocalEvent(_activeEntity.Owner, ev);
+            RaiseEvent(_activeEntity.Owner, ev);
 
             return TurnOrderState.PassTurns;
         }
@@ -470,7 +470,7 @@ namespace OpenNefia.Content.TurnOrder
             _field.RefreshScreen();
 
             var ev = new PlayerDiedEventArgs();
-            RaiseLocalEvent(_gameSession.Player, ev);
+            RaiseEvent(_gameSession.Player, ev);
             if (ev.Handled) 
             {
                 return ev.TurnResult.ToTurnOrderState();

--- a/OpenNefia.Content/VanillaAI/AIAnchorSystem.cs
+++ b/OpenNefia.Content/VanillaAI/AIAnchorSystem.cs
@@ -16,8 +16,8 @@ namespace OpenNefia.Content.VanillaAI
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<VanillaAIComponent, EntityGeneratedEvent>(HandleGenerated);
-            SubscribeLocalEvent<AIAnchorComponent, ComponentStartup>(HandleStartup);
+            SubscribeComponent<VanillaAIComponent, EntityGeneratedEvent>(HandleGenerated);
+            SubscribeComponent<AIAnchorComponent, ComponentStartup>(HandleStartup);
         }
 
         private void HandleGenerated(EntityUid uid, VanillaAIComponent ai, ref EntityGeneratedEvent args)

--- a/OpenNefia.Content/VanillaAI/VanillaAISystem.Actions.cs
+++ b/OpenNefia.Content/VanillaAI/VanillaAISystem.Actions.cs
@@ -16,7 +16,7 @@ namespace OpenNefia.Content.VanillaAI
 
         private void SubscribeAIActions()
         {
-            SubscribeLocalEvent<AIActionMeleeComponent, RunAIActionEvent>(HandleActionMelee);
+            SubscribeComponent<AIActionMeleeComponent, RunAIActionEvent>(HandleActionMelee);
         }
 
         private void HandleActionMelee(EntityUid action, AIActionMeleeComponent component, RunAIActionEvent args)

--- a/OpenNefia.Content/VanillaAI/VanillaAISystem.cs
+++ b/OpenNefia.Content/VanillaAI/VanillaAISystem.cs
@@ -44,7 +44,7 @@ namespace OpenNefia.Content.VanillaAI
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<VanillaAIComponent, NPCTurnStartedEvent>(HandleNPCTurnStarted, priority: EventPriorities.VeryLow);
+            SubscribeComponent<VanillaAIComponent, NPCTurnStartedEvent>(HandleNPCTurnStarted, priority: EventPriorities.VeryLow);
             SubscribeAIActions();
         }
 

--- a/OpenNefia.Content/VanillaAI/VanillaAISystem.cs
+++ b/OpenNefia.Content/VanillaAI/VanillaAISystem.cs
@@ -310,7 +310,7 @@ namespace OpenNefia.Content.VanillaAI
         private TurnResult RunAIAction(EntityUid entity, EntityUid action)
         {
             var ev = new RunAIActionEvent(entity);
-            RaiseLocalEvent(action, ev);
+            RaiseEvent(action, ev);
             return ev.TurnResult;
         }
 

--- a/OpenNefia.Content/World/WorldSystem.cs
+++ b/OpenNefia.Content/World/WorldSystem.cs
@@ -94,22 +94,22 @@ namespace OpenNefia.Content.World
                 if (hoursPassed > 0)
                 {
                     var ev = new MapOnHoursPassedEvent(hoursPassed);
-                    RaiseLocalEvent(map.MapEntityUid, ref ev);
+                    RaiseEvent(map.MapEntityUid, ref ev);
                 }
                 if (daysPassed > 0)
                 {
                     var ev = new MapOnDaysPassedEvent(daysPassed);
-                    RaiseLocalEvent(map.MapEntityUid, ref ev);
+                    RaiseEvent(map.MapEntityUid, ref ev);
                 }
                 if (monthsPassed > 0)
                 {
                     var ev = new MapOnMonthsPassedEvent(monthsPassed);
-                    RaiseLocalEvent(map.MapEntityUid, ref ev);
+                    RaiseEvent(map.MapEntityUid, ref ev);
                 }
                 if (yearsPassed > 0)
                 {
                     var ev = new MapOnYearsPassedEvent(yearsPassed);
-                    RaiseLocalEvent(map.MapEntityUid, ref ev);
+                    RaiseEvent(map.MapEntityUid, ref ev);
                 }
             }
         }

--- a/OpenNefia.Content/WorldMap/WorldMapSystem.cs
+++ b/OpenNefia.Content/WorldMap/WorldMapSystem.cs
@@ -26,7 +26,7 @@ namespace OpenNefia.Content.WorldMap
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<MapEnterEvent>(CheckCloudLayer);
+            SubscribeBroadcast<MapEnterEvent>(CheckCloudLayer);
         }
 
         private void CheckCloudLayer(MapEnterEvent ev)

--- a/OpenNefia.Core/Areas/AreaManager.MapRegistry.cs
+++ b/OpenNefia.Core/Areas/AreaManager.MapRegistry.cs
@@ -108,7 +108,7 @@ namespace OpenNefia.Core.Areas
             var previousCoords = _entityManager.GetComponent<SpatialComponent>(player).MapPosition;
 
             var ev = new AreaFloorGenerateEvent(area, floorId, previousCoords);
-            _entityManager.EventBus.RaiseLocalEvent(area.AreaEntityUid, ev);
+            _entityManager.EventBus.RaiseEvent(area.AreaEntityUid, ev);
 
             if (ev.ResultMapId == null)
             {

--- a/OpenNefia.Core/Areas/AreaManager.cs
+++ b/OpenNefia.Core/Areas/AreaManager.cs
@@ -204,7 +204,7 @@ namespace OpenNefia.Core.Areas
             }
 
             var ev = new AreaGeneratedEvent(area);
-            _entityManager.EventBus.RaiseLocalEvent(area.AreaEntityUid, ev);
+            _entityManager.EventBus.RaiseEvent(area.AreaEntityUid, ev);
 
             return area;
         }

--- a/OpenNefia.Core/Areas/AreaSystem.cs
+++ b/OpenNefia.Core/Areas/AreaSystem.cs
@@ -14,9 +14,9 @@ namespace OpenNefia.Core.Areas
 
             _areaManager.OnActiveAreaChanged += OnActiveAreaChanged;
 
-            SubscribeLocalEvent<AreaComponent, ComponentAdd>(OnAreaAdd);
-            SubscribeLocalEvent<AreaComponent, ComponentInit>(OnAreaInit);
-            SubscribeLocalEvent<AreaComponent, ComponentStartup>(OnAreaStartup);
+            SubscribeComponent<AreaComponent, ComponentAdd>(OnAreaAdd);
+            SubscribeComponent<AreaComponent, ComponentInit>(OnAreaInit);
+            SubscribeComponent<AreaComponent, ComponentStartup>(OnAreaStartup);
         }
 
         private void OnActiveAreaChanged(IArea? newArea, IArea? oldArea)
@@ -36,19 +36,19 @@ namespace OpenNefia.Core.Areas
         private void OnAreaAdd(EntityUid uid, AreaComponent component, ComponentAdd args)
         {
             var msg = new AreaAddEvent(uid, component.AreaId);
-            EntityManager.EventBus.RaiseLocalEvent(uid, msg);
+            EntityManager.EventBus.RaiseEvent(uid, msg);
         }
 
         private void OnAreaInit(EntityUid uid, AreaComponent component, ComponentInit args)
         {
             var msg = new AreaInitializeEvent(uid, component.AreaId);
-            EntityManager.EventBus.RaiseLocalEvent(uid, msg);
+            EntityManager.EventBus.RaiseEvent(uid, msg);
         }
 
         private void OnAreaStartup(EntityUid uid, AreaComponent component, ComponentStartup args)
         {
             var msg = new AreaStartupEvent(uid, component.AreaId);
-            EntityManager.EventBus.RaiseLocalEvent(uid, msg);
+            EntityManager.EventBus.RaiseEvent(uid, msg);
         }
     }
 

--- a/OpenNefia.Core/Areas/AreaSystem.cs
+++ b/OpenNefia.Core/Areas/AreaSystem.cs
@@ -24,12 +24,12 @@ namespace OpenNefia.Core.Areas
             if (oldArea != null)
             {
                 var ev = new AreaExitedEvent(newArea, oldArea);
-                RaiseLocalEvent(oldArea.AreaEntityUid, ev);
+                RaiseEvent(oldArea.AreaEntityUid, ev);
             }
             if (newArea != null)
             {
                 var ev = new AreaEnteredEvent(newArea, oldArea);
-                RaiseLocalEvent(newArea.AreaEntityUid, ev);
+                RaiseEvent(newArea.AreaEntityUid, ev);
             }
         }
 

--- a/OpenNefia.Core/Audio/AudioSystem.cs
+++ b/OpenNefia.Core/Audio/AudioSystem.cs
@@ -12,7 +12,7 @@ namespace OpenNefia.Core.Audio
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<PlayerComponent, EntityPositionChangedEvent>(OnPlayerPositionChanged);
+            SubscribeComponent<PlayerComponent, EntityPositionChangedEvent>(OnPlayerPositionChanged);
         }
 
         // TODO: when implementing scrolling, run this every frame to account for sub-tile positioning.

--- a/OpenNefia.Core/Containers/BaseContainer.cs
+++ b/OpenNefia.Core/Containers/BaseContainer.cs
@@ -97,12 +97,12 @@ namespace OpenNefia.Core.Containers
 
             //raise events
             var insertAttemptEvent = new ContainerIsInsertingAttemptEvent(this, toinsert);
-            entMan.EventBus.RaiseLocalEvent(Owner, insertAttemptEvent);
+            entMan.EventBus.RaiseEvent(Owner, insertAttemptEvent);
             if (insertAttemptEvent.Cancelled)
                 return false;
 
             var gettingInsertedAttemptEvent = new ContainerGettingInsertedAttemptEvent(this, toinsert);
-            entMan.EventBus.RaiseLocalEvent(toinsert, gettingInsertedAttemptEvent);
+            entMan.EventBus.RaiseEvent(toinsert, gettingInsertedAttemptEvent);
             if (gettingInsertedAttemptEvent.Cancelled)
                 return false;
 
@@ -149,12 +149,12 @@ namespace OpenNefia.Core.Containers
 
             //raise events
             var removeAttemptEvent = new ContainerIsRemovingAttemptEvent(this, toremove);
-            entMan.EventBus.RaiseLocalEvent(Owner, removeAttemptEvent);
+            entMan.EventBus.RaiseEvent(Owner, removeAttemptEvent);
             if (removeAttemptEvent.Cancelled)
                 return false;
 
             var gettingRemovedAttemptEvent = new ContainerGettingRemovedAttemptEvent(this, toremove);
-            entMan.EventBus.RaiseLocalEvent(toremove, gettingRemovedAttemptEvent);
+            entMan.EventBus.RaiseEvent(toremove, gettingRemovedAttemptEvent);
             if (gettingRemovedAttemptEvent.Cancelled)
                 return false;
 
@@ -180,7 +180,7 @@ namespace OpenNefia.Core.Containers
         {
             DebugTools.Assert(!Deleted);
 
-            entMan.EventBus.RaiseLocalEvent(Owner, new EntInsertedIntoContainerMessage(toinsert, this));
+            entMan.EventBus.RaiseEvent(Owner, new EntInsertedIntoContainerMessage(toinsert, this));
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace OpenNefia.Core.Containers
             DebugTools.AssertNotNull(toremove);
             DebugTools.Assert(entMan.EntityExists(toremove));
 
-            entMan.EventBus.RaiseLocalEvent(Owner, new EntRemovedFromContainerMessage(toremove, this));
+            entMan.EventBus.RaiseEvent(Owner, new EntRemovedFromContainerMessage(toremove, this));
         }
     }
 }

--- a/OpenNefia.Core/Containers/ContainerManagerComponent.cs
+++ b/OpenNefia.Core/Containers/ContainerManagerComponent.cs
@@ -79,8 +79,7 @@ namespace OpenNefia.Core.Containers
             {
                 foreach (var containerEntity in container.ContainedEntities)
                 {
-                    _entityManager.EventBus.RaiseEvent(EventSource.Local,
-                        new UpdateContainerOcclusionEvent(containerEntity));
+                    _entityManager.EventBus.RaiseEvent(new UpdateContainerOcclusionEvent(containerEntity));
                 }
             }
         }

--- a/OpenNefia.Core/Containers/ContainerSystem.cs
+++ b/OpenNefia.Core/Containers/ContainerSystem.cs
@@ -18,7 +18,7 @@ namespace OpenNefia.Core.Containers
         {
             base.Initialize();
 
-            SubscribeLocalEvent<EntityParentChangedEvent>(HandleParentChanged);
+            SubscribeBroadcast<EntityParentChangedEvent>(HandleParentChanged);
         }
 
         #region Container Management

--- a/OpenNefia.Core/Containers/ContainerSystem.cs
+++ b/OpenNefia.Core/Containers/ContainerSystem.cs
@@ -18,7 +18,7 @@ namespace OpenNefia.Core.Containers
         {
             base.Initialize();
 
-            SubscribeBroadcast<EntityParentChangedEvent>(HandleParentChanged);
+            SubscribeEntity<EntityParentChangedEvent>(HandleParentChanged);
         }
 
         #region Container Management
@@ -254,7 +254,7 @@ namespace OpenNefia.Core.Containers
         #region Event Handlers
 
         // Eject entities from their parent container if the parent change is done by the transform only.
-        private void HandleParentChanged(ref EntityParentChangedEvent message)
+        private void HandleParentChanged(EntityUid entity, ref EntityParentChangedEvent message)
         {
             var oldParentEntity = message.OldParent;
 
@@ -262,7 +262,7 @@ namespace OpenNefia.Core.Containers
                 return;
 
             if (EntityManager.TryGetComponent(oldParentEntity!.Value, out ContainerManagerComponent? containerManager))
-                ForceRemove(message.EntityUid, containerManager);
+                ForceRemove(entity, containerManager);
         }
 
         #endregion

--- a/OpenNefia.Core/GameObjects/Component.cs
+++ b/OpenNefia.Core/GameObjects/Component.cs
@@ -150,7 +150,7 @@ namespace OpenNefia.Core.GameObjects
         /// </summary>
         protected virtual void OnAdd()
         {
-            GetBus().RaiseComponentEvent(this, CompAddInstance);
+            GetBus().RaiseDirectedComponentEvent(this, CompAddInstance);
             LifeStage = ComponentLifeStage.Added;
         }
 
@@ -160,7 +160,7 @@ namespace OpenNefia.Core.GameObjects
         /// </summary>
         protected virtual void Initialize()
         {
-            GetBus().RaiseComponentEvent(this, CompInitInstance);
+            GetBus().RaiseDirectedComponentEvent(this, CompInitInstance);
             LifeStage = ComponentLifeStage.Initialized;
         }
 
@@ -172,7 +172,7 @@ namespace OpenNefia.Core.GameObjects
         /// </remarks>
         protected virtual void Startup()
         {
-            GetBus().RaiseComponentEvent(this, CompStartupInstance);
+            GetBus().RaiseDirectedComponentEvent(this, CompStartupInstance);
             LifeStage = ComponentLifeStage.Running;
         }
 
@@ -181,7 +181,7 @@ namespace OpenNefia.Core.GameObjects
         /// </summary>
         protected virtual void Shutdown()
         {
-            GetBus().RaiseComponentEvent(this, CompShutdownInstance);
+            GetBus().RaiseDirectedComponentEvent(this, CompShutdownInstance);
             LifeStage = ComponentLifeStage.Stopped;
         }
 
@@ -192,7 +192,7 @@ namespace OpenNefia.Core.GameObjects
         /// </summary>
         protected virtual void OnRemove()
         {
-            GetBus().RaiseComponentEvent(this, CompRemoveInstance);
+            GetBus().RaiseDirectedComponentEvent(this, CompRemoveInstance);
             LifeStage = ComponentLifeStage.Deleted;
         }
     }

--- a/OpenNefia.Core/GameObjects/Components/MetaDataComponent.cs
+++ b/OpenNefia.Core/GameObjects/Components/MetaDataComponent.cs
@@ -72,7 +72,7 @@ namespace OpenNefia.Core.GameObjects
                 _liveness = value;
 
                 var livenessEvent = new EntityLivenessChangedEvent(Owner, oldLiveness, Liveness);
-                _entityManager.EventBus.RaiseLocalEvent(Owner, ref livenessEvent);
+                _entityManager.EventBus.RaiseEvent(Owner, ref livenessEvent);
             }
         }
 

--- a/OpenNefia.Core/GameObjects/Components/SpatialComponent.cs
+++ b/OpenNefia.Core/GameObjects/Components/SpatialComponent.cs
@@ -245,7 +245,7 @@ namespace OpenNefia.Core.GameObjects
                 _parent = value.EntityId;
                 ChangeMapId(newParent.MapID);
 
-                var entParentChangedMessage = new EntityParentChangedEvent(Owner, oldParent?.Owner);
+                var entParentChangedMessage = new EntityParentChangedEvent(oldParent?.Owner);
                 _entityManager.EventBus.RaiseEvent(Owner, ref entParentChangedMessage);
             }
 
@@ -257,7 +257,7 @@ namespace OpenNefia.Core.GameObjects
 
             if (!noEvents)
             {
-                var moveEvent = new EntityPositionChangedEvent(Owner, oldPosition, Coordinates, this);
+                var moveEvent = new EntityPositionChangedEvent(oldPosition, Coordinates, this);
                 _entityManager.EventBus.RaiseEvent(Owner, ref moveEvent);
             }
         }
@@ -292,7 +292,7 @@ namespace OpenNefia.Core.GameObjects
 
             if (!noEvents)
             {
-                var moveEvent = new EntityPositionChangedEvent(Owner, oldPos, Coordinates, this);
+                var moveEvent = new EntityPositionChangedEvent(oldPos, Coordinates, this);
                 _entityManager.EventBus.RaiseEvent(Owner, ref moveEvent);
             }
         }
@@ -418,7 +418,7 @@ namespace OpenNefia.Core.GameObjects
             _parent = EntityUid.Invalid;
             var oldMapId = MapID;
             MapID = MapId.Nullspace;
-            var entParentChangedMessage = new EntityParentChangedEvent(Owner, oldParent?.Owner);
+            var entParentChangedMessage = new EntityParentChangedEvent(oldParent?.Owner);
             _entityManager.EventBus.RaiseEvent(Owner, ref entParentChangedMessage);
 
             // Does it even make sense to call these since this is called purely from OnRemove right now?
@@ -568,15 +568,13 @@ namespace OpenNefia.Core.GameObjects
     [ByRefEvent]
     public readonly struct EntityPositionChangedEvent
     {
-        public EntityPositionChangedEvent(EntityUid entityUid, EntityCoordinates oldPos, EntityCoordinates newPos, SpatialComponent component)
+        public EntityPositionChangedEvent(EntityCoordinates oldPos, EntityCoordinates newPos, SpatialComponent component)
         {
-            EntityUid = entityUid;
             OldPosition = oldPos;
             NewPosition = newPos;
             Component = component;
         }
 
-        public readonly EntityUid EntityUid;
         public readonly EntityCoordinates OldPosition;
         public readonly EntityCoordinates NewPosition;
         public readonly SpatialComponent Component;
@@ -589,11 +587,6 @@ namespace OpenNefia.Core.GameObjects
     public struct EntityParentChangedEvent
     {
         /// <summary>
-        ///     Entity that was adopted. The transform component has a property with the new parent.
-        /// </summary>
-        public EntityUid EntityUid { get; }
-
-        /// <summary>
         ///     Old parent that abandoned the Entity.
         /// </summary>
         public EntityUid? OldParent { get; }
@@ -603,9 +596,8 @@ namespace OpenNefia.Core.GameObjects
         /// </summary>
         /// <param name="entity"></param>
         /// <param name="oldParent"></param>
-        public EntityParentChangedEvent(EntityUid entity, EntityUid? oldParent)
+        public EntityParentChangedEvent(EntityUid? oldParent)
         {
-            EntityUid = entity;
             OldParent = oldParent;
         }
     }

--- a/OpenNefia.Core/GameObjects/Components/SpatialComponent.cs
+++ b/OpenNefia.Core/GameObjects/Components/SpatialComponent.cs
@@ -191,7 +191,7 @@ namespace OpenNefia.Core.GameObjects
                 _isSolid = value;
 
                 var ev = new EntityTangibilityChangedEvent();
-                _entityManager.EventBus.RaiseLocalEvent(Owner, ref ev);
+                _entityManager.EventBus.RaiseEvent(Owner, ref ev);
             } 
         }
 
@@ -209,7 +209,7 @@ namespace OpenNefia.Core.GameObjects
                 _isOpaque = value;
 
                 var ev = new EntityTangibilityChangedEvent();
-                _entityManager.EventBus.RaiseLocalEvent(Owner, ref ev);
+                _entityManager.EventBus.RaiseEvent(Owner, ref ev);
             }
         }
 
@@ -246,7 +246,7 @@ namespace OpenNefia.Core.GameObjects
                 ChangeMapId(newParent.MapID);
 
                 var entParentChangedMessage = new EntityParentChangedEvent(Owner, oldParent?.Owner);
-                _entityManager.EventBus.RaiseLocalEvent(Owner, ref entParentChangedMessage);
+                _entityManager.EventBus.RaiseEvent(Owner, ref entParentChangedMessage);
             }
 
             // These conditions roughly emulate the effects of the code before I changed things,
@@ -258,7 +258,7 @@ namespace OpenNefia.Core.GameObjects
             if (!noEvents)
             {
                 var moveEvent = new EntityPositionChangedEvent(Owner, oldPosition, Coordinates, this);
-                _entityManager.EventBus.RaiseLocalEvent(Owner, ref moveEvent);
+                _entityManager.EventBus.RaiseEvent(Owner, ref moveEvent);
             }
         }
 
@@ -293,7 +293,7 @@ namespace OpenNefia.Core.GameObjects
             if (!noEvents)
             {
                 var moveEvent = new EntityPositionChangedEvent(Owner, oldPos, Coordinates, this);
-                _entityManager.EventBus.RaiseLocalEvent(Owner, ref moveEvent);
+                _entityManager.EventBus.RaiseEvent(Owner, ref moveEvent);
             }
         }
 
@@ -419,7 +419,7 @@ namespace OpenNefia.Core.GameObjects
             var oldMapId = MapID;
             MapID = MapId.Nullspace;
             var entParentChangedMessage = new EntityParentChangedEvent(Owner, oldParent?.Owner);
-            _entityManager.EventBus.RaiseLocalEvent(Owner, ref entParentChangedMessage);
+            _entityManager.EventBus.RaiseEvent(Owner, ref entParentChangedMessage);
 
             // Does it even make sense to call these since this is called purely from OnRemove right now?
             RebuildMatrices();
@@ -476,7 +476,7 @@ namespace OpenNefia.Core.GameObjects
 
         private void MapIdChanged(MapId oldId)
         {
-            _entityManager.EventBus.RaiseLocalEvent(Owner, new EntMapIdChangedEvent(Owner, oldId));
+            _entityManager.EventBus.RaiseEvent(Owner, new EntMapIdChangedEvent(Owner, oldId));
         }
 
         public void AttachParent(EntityUid parent)

--- a/OpenNefia.Core/GameObjects/EntityEventBus.Broadcast.cs
+++ b/OpenNefia.Core/GameObjects/EntityEventBus.Broadcast.cs
@@ -215,16 +215,24 @@ namespace OpenNefia.Core.GameObjects
                 foreach (var handler in subs)
                 {
                     if (handler.ReferenceEvent != byRef)
-                        ThrowByRefMisMatch();
+                        ThrowByRefMisMatch(handler.ReferenceEvent);
 
                     handler.Handler(ref unitRef);
                 }
             }
         }
+        
+        private const string ValueDispatchError = "Tried to dispatch a value event to a by-reference subscription.";
+        private const string RefDispatchError = "Tried to dispatch a ref event to a by-value subscription.";
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowByRefMisMatch() =>
-            throw new InvalidOperationException("Mismatching by-ref ness on event!");
+        private static void ThrowByRefMisMatch(bool subIsByRef)
+        {
+            if (subIsByRef)
+                throw new InvalidOperationException(ValueDispatchError);
+            else
+                throw new InvalidOperationException(RefDispatchError);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ref Unit ExtractUnitRef(ref object obj, Type objType)

--- a/OpenNefia.Core/GameObjects/EntityEventBus.Broadcast.cs
+++ b/OpenNefia.Core/GameObjects/EntityEventBus.Broadcast.cs
@@ -24,15 +24,15 @@ namespace OpenNefia.Core.GameObjects
         /// <param name="source"></param>
         /// <param name="subscriber">Subscriber that owns the handler.</param>
         /// <param name="eventHandler">Delegate that handles the event.</param>
-        void SubscribeEvent<T>(
+        void SubscribeBroadcastEvent<T>(
             IEntityEventSubscriber subscriber,
-            EntityEventHandler<T> eventHandler,
+            BroadcastEventHandler<T> eventHandler,
             long priority = EventPriorities.Default)
             where T : notnull;
 
-        void SubscribeEvent<T>(
+        void SubscribeBroadcastEvent<T>(
             IEntityEventSubscriber subscriber,
-            EntityEventRefHandler<T> eventHandler,
+            BroadcastEventRefHandler<T> eventHandler,
             long priority = EventPriorities.Default)
             where T : notnull;
 
@@ -98,9 +98,9 @@ namespace OpenNefia.Core.GameObjects
         }
 
         /// <inheritdoc />
-        public void SubscribeEvent<T>(
+        public void SubscribeBroadcastEvent<T>(
             IEntityEventSubscriber subscriber,
-            EntityEventHandler<T> eventHandler,
+            BroadcastEventHandler<T> eventHandler,
             long priority = EventPriorities.Default)
             where T : notnull
         {
@@ -113,7 +113,7 @@ namespace OpenNefia.Core.GameObjects
                 eventHandler, order, false);
         }
 
-        public void SubscribeEvent<T>(IEntityEventSubscriber subscriber, EntityEventRefHandler<T> eventHandler,
+        public void SubscribeBroadcastEvent<T>(IEntityEventSubscriber subscriber, BroadcastEventRefHandler<T> eventHandler,
             long priority = EventPriorities.Default) where T : notnull
         {
             var order = new OrderingData(priority, _nextEventIndex++);

--- a/OpenNefia.Core/GameObjects/EntityEventBus.Directed.cs
+++ b/OpenNefia.Core/GameObjects/EntityEventBus.Directed.cs
@@ -12,12 +12,12 @@ namespace OpenNefia.Core.GameObjects
 
     public interface IDirectedEventBus
     {
-        void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
+        void RaiseEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
             where TEvent : notnull;
 
-        void RaiseLocalEvent(EntityUid uid, object args, bool broadcast = true);
+        void RaiseEvent(EntityUid uid, object args, bool broadcast = true);
 
-        void SubscribeLocalEvent<TComp, TEvent>(
+        void SubscribeComponentEvent<TComp, TEvent>(
             ComponentEventHandler<TComp, TEvent> handler,
             long priority = EventPriorities.Default)
             where TComp : IComponent
@@ -25,12 +25,12 @@ namespace OpenNefia.Core.GameObjects
 
         #region Ref Subscriptions
 
-        void RaiseLocalEvent<TEvent>(EntityUid uid, ref TEvent args, bool broadcast = true)
+        void RaiseEvent<TEvent>(EntityUid uid, ref TEvent args, bool broadcast = true)
             where TEvent : notnull;
 
-        void RaiseLocalEvent(EntityUid uid, ref object args, bool broadcast = true);
+        void RaiseEvent(EntityUid uid, ref object args, bool broadcast = true);
 
-        void SubscribeLocalEvent<TComp, TEvent>(
+        void SubscribeComponentEvent<TComp, TEvent>(
             ComponentEventRefHandler<TComp, TEvent> handler,
             long priority = EventPriorities.Default)
             where TComp : IComponent
@@ -38,7 +38,7 @@ namespace OpenNefia.Core.GameObjects
 
         #endregion
 
-        void UnsubscribeAllLocalEvents<TComp, TEvent>()
+        void UnsubscribeAllComponentEvents<TComp, TEvent>()
             where TComp : IComponent
             where TEvent : notnull;
 
@@ -52,7 +52,7 @@ namespace OpenNefia.Core.GameObjects
         /// <typeparam name="TEvent">Event to dispatch.</typeparam>
         /// <param name="component">Component receiving the event.</param>
         /// <param name="args">Event arguments for the event.</param>
-        internal void RaiseComponentEvent<TEvent>(IComponent component, TEvent args)
+        internal void RaiseDirectedComponentEvent<TEvent>(IComponent component, TEvent args)
             where TEvent : notnull;
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace OpenNefia.Core.GameObjects
         /// <typeparam name="TEvent">Event to dispatch.</typeparam>
         /// <param name="component">Component receiving the event.</param>
         /// <param name="args">Event arguments for the event.</param>
-        internal void RaiseComponentEvent<TEvent>(IComponent component, ref TEvent args)
+        internal void RaiseDirectedComponentEvent<TEvent>(IComponent component, ref TEvent args)
             where TEvent : notnull;
     }
 
@@ -91,7 +91,7 @@ namespace OpenNefia.Core.GameObjects
         }
 
         /// <inheritdoc />
-        void IDirectedEventBus.RaiseComponentEvent<TEvent>(IComponent component, TEvent args)
+        void IDirectedEventBus.RaiseDirectedComponentEvent<TEvent>(IComponent component, TEvent args)
         {
             ref var unitRef = ref Unsafe.As<TEvent, Unit>(ref args);
 
@@ -99,7 +99,7 @@ namespace OpenNefia.Core.GameObjects
         }
 
         /// <inheritdoc />
-        void IDirectedEventBus.RaiseComponentEvent<TEvent>(IComponent component, ref TEvent args)
+        void IDirectedEventBus.RaiseDirectedComponentEvent<TEvent>(IComponent component, ref TEvent args)
         {
             ref var unitRef = ref Unsafe.As<TEvent, Unit>(ref args);
 
@@ -107,42 +107,42 @@ namespace OpenNefia.Core.GameObjects
         }
 
         /// <inheritdoc />
-        public void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
+        public void RaiseEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
             where TEvent : notnull
         {
             var type = typeof(TEvent);
             ref var unitRef = ref Unsafe.As<TEvent, Unit>(ref args);
 
-            RaiseLocalEventCore(uid, ref unitRef, type, broadcast, false);
+            RaiseEventCore(uid, ref unitRef, type, broadcast, false);
         }
 
         /// <inheritdoc />
-        public void RaiseLocalEvent(EntityUid uid, object args, bool broadcast = true)
+        public void RaiseEvent(EntityUid uid, object args, bool broadcast = true)
         {
             var type = args.GetType();
             ref var unitRef = ref Unsafe.As<object, Unit>(ref args);
 
-            RaiseLocalEventCore(uid, ref unitRef, type, broadcast, false);
+            RaiseEventCore(uid, ref unitRef, type, broadcast, false);
         }
 
-        public void RaiseLocalEvent<TEvent>(EntityUid uid, ref TEvent args, bool broadcast = true)
+        public void RaiseEvent<TEvent>(EntityUid uid, ref TEvent args, bool broadcast = true)
             where TEvent : notnull
         {
             var type = typeof(TEvent);
             ref var unitRef = ref Unsafe.As<TEvent, Unit>(ref args);
 
-            RaiseLocalEventCore(uid, ref unitRef, type, broadcast, true);
+            RaiseEventCore(uid, ref unitRef, type, broadcast, true);
         }
 
-        public void RaiseLocalEvent(EntityUid uid, ref object args, bool broadcast = true)
+        public void RaiseEvent(EntityUid uid, ref object args, bool broadcast = true)
         {
             var type = args.GetType();
             ref var unitRef = ref Unsafe.As<object, Unit>(ref args);
 
-            RaiseLocalEventCore(uid, ref unitRef, type, broadcast, true);
+            RaiseEventCore(uid, ref unitRef, type, broadcast, true);
         }
 
-        private void RaiseLocalEventCore(EntityUid uid, ref Unit unitRef, Type eventType, bool broadcast, bool byRef)
+        private void RaiseEventCore(EntityUid uid, ref Unit unitRef, Type eventType, bool broadcast, bool byRef)
         {
             if (!_eventTables.TryGetEntityTable(uid, eventType, out var table))
             {
@@ -171,7 +171,7 @@ namespace OpenNefia.Core.GameObjects
         }
 
         /// <inheritdoc />
-        public void SubscribeLocalEvent<TComp, TEvent>(
+        public void SubscribeComponentEvent<TComp, TEvent>(
             ComponentEventHandler<TComp, TEvent> handler,
             long priority = EventPriorities.Default)
             where TComp : IComponent
@@ -185,7 +185,7 @@ namespace OpenNefia.Core.GameObjects
             _eventTables.Subscribe<TEvent>(typeof(TComp), typeof(TEvent), EventHandler, orderData, false);
         }
 
-        public void SubscribeLocalEvent<TComp, TEvent>(ComponentEventRefHandler<TComp, TEvent> handler,
+        public void SubscribeComponentEvent<TComp, TEvent>(ComponentEventRefHandler<TComp, TEvent> handler,
             long priority = EventPriorities.Default) where TComp : IComponent where TEvent : notnull
         {
             void EventHandler(EntityUid uid, IComponent comp, ref TEvent args)
@@ -197,7 +197,7 @@ namespace OpenNefia.Core.GameObjects
         }
 
         /// <inheritdoc />
-        public void UnsubscribeAllLocalEvents<TComp, TEvent>()
+        public void UnsubscribeAllComponentEvents<TComp, TEvent>()
             where TComp : IComponent
             where TEvent : notnull
         {

--- a/OpenNefia.Core/GameObjects/EntityEventBus.Directed.cs
+++ b/OpenNefia.Core/GameObjects/EntityEventBus.Directed.cs
@@ -150,7 +150,7 @@ namespace OpenNefia.Core.GameObjects
                 // This is important if no component event handlers are registered, but there are
                 // still broadcast handlers.
                 if (broadcast)
-                    ProcessBroadcastEvent(EventSource.Local, ref unitRef, eventType, byRef);
+                    ProcessBroadcastEvent(ref unitRef, eventType, byRef);
                 
                 return;
             }
@@ -162,7 +162,7 @@ namespace OpenNefia.Core.GameObjects
                 var found = new List<(HandlerAndCompType, OrderingData)>();
                 
                 _eventTables.CollectOrdered(uid, eventType, found, byRef);
-                CollectBroadcastOrdered(EventSource.Local, eventType, found, byRef);
+                CollectBroadcastOrdered(eventType, found, byRef);
 
                 table.Set(found);
             }

--- a/OpenNefia.Core/GameObjects/EntityEventBus.Ordering.cs
+++ b/OpenNefia.Core/GameObjects/EntityEventBus.Ordering.cs
@@ -8,7 +8,6 @@ namespace OpenNefia.Core.GameObjects
     internal partial class EntityEventBus
     {
         private void CollectBroadcastOrdered(
-            EventSource source,
             Type eventType,
             List<(HandlerAndCompType, OrderingData)> found,
             bool byRef)
@@ -21,8 +20,7 @@ namespace OpenNefia.Core.GameObjects
                 if (handler.ReferenceEvent != byRef)
                     ThrowByRefMisMatch();
 
-                if ((handler.Mask & source) != 0)
-                    found.Add((new(handler.Handler, null), handler.Ordering));
+                found.Add((new(handler.Handler, null), handler.Ordering));
             }
         }
 

--- a/OpenNefia.Core/GameObjects/EntityEventBus.Ordering.cs
+++ b/OpenNefia.Core/GameObjects/EntityEventBus.Ordering.cs
@@ -18,7 +18,7 @@ namespace OpenNefia.Core.GameObjects
             foreach (var handler in subs)
             {
                 if (handler.ReferenceEvent != byRef)
-                    ThrowByRefMisMatch();
+                    ThrowByRefMisMatch(handler.ReferenceEvent);
 
                 found.Add((new(handler.Handler, null), handler.Ordering));
             }

--- a/OpenNefia.Core/GameObjects/EntityEvents.cs
+++ b/OpenNefia.Core/GameObjects/EntityEvents.cs
@@ -4,8 +4,8 @@ namespace OpenNefia.Core.GameObjects
 {
     public interface IEntityEventSubscriber { }
 
-    public delegate void EntityEventHandler<in T>(T ev);
-    public delegate void EntityEventRefHandler<T>(ref T ev);
+    public delegate void BroadcastEventHandler<in T>(T ev);
+    public delegate void BroadcastEventRefHandler<T>(ref T ev);
 
     [Serializable]
     public abstract class EntityEventArgs { }

--- a/OpenNefia.Core/GameObjects/EntityManager.Components.cs
+++ b/OpenNefia.Core/GameObjects/EntityManager.Components.cs
@@ -153,7 +153,7 @@ namespace OpenNefia.Core.GameObjects
 #endif
             DebugTools.Assert(metadata.EntityLifeStage == EntityLifeStage.Initializing);
             metadata.EntityLifeStage = EntityLifeStage.Initialized;
-            EventBus.RaiseEvent(EventSource.Local, new EntityInitializedEvent(uid));
+            EventBus.RaiseEvent(new EntityInitializedEvent(uid));
         }
 
         public void StartComponents(EntityUid uid)

--- a/OpenNefia.Core/GameObjects/EntityManager.cs
+++ b/OpenNefia.Core/GameObjects/EntityManager.cs
@@ -207,7 +207,7 @@ namespace OpenNefia.Core.GameObjects
             metadata.EntityLifeStage = EntityLifeStage.Terminating;
             metadata.Liveness = EntityGameLiveness.DeadAndBuried;
 
-            EventBus.RaiseLocalEvent(uid, ref EntityTerminating, false);
+            EventBus.RaiseEvent(uid, ref EntityTerminating, false);
 
             // DeleteEntity modifies our _children collection, we must cache the collection to iterate properly
             foreach (var child in spatial._children.ToArray())

--- a/OpenNefia.Core/GameObjects/EntityManager.cs
+++ b/OpenNefia.Core/GameObjects/EntityManager.cs
@@ -235,7 +235,7 @@ namespace OpenNefia.Core.GameObjects
 
             metadata.EntityLifeStage = EntityLifeStage.Deleted;
             EntityDeleted?.Invoke(this, uid);
-            EventBus.RaiseEvent(EventSource.Local, new EntityDeletedEvent(uid));
+            EventBus.RaiseEvent(new EntityDeletedEvent(uid));
             Entities.Remove(uid);
         }
 

--- a/OpenNefia.Core/GameObjects/EntitySystem.Raise.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystem.Raise.cs
@@ -16,7 +16,7 @@ namespace OpenNefia.Core.GameObjects
         public bool Raise<T>(EntityUid uid, T args)
             where T : HandledEntityEventArgs
         {
-            RaiseLocalEvent(uid, args);
+            RaiseEvent(uid, args);
             return args.Handled || !EntityManager.IsAlive(uid);
         }
 
@@ -24,7 +24,7 @@ namespace OpenNefia.Core.GameObjects
             where T1 : TurnResultEntityEventArgs
             where T2 : TurnResultEntityEventArgs
         {
-            RaiseLocalEvent(uid, args);
+            RaiseEvent(uid, args);
             
             if (args.Handled || !EntityManager.IsAlive(uid))
             {

--- a/OpenNefia.Core/GameObjects/EntitySystem.Subscriptions.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystem.Subscriptions.cs
@@ -60,7 +60,7 @@ namespace OpenNefia.Core.GameObjects
             EntityManager.EventBus.SubscribeComponentEvent(handler, priority);
 
             _subscriptions ??= new();
-            _subscriptions.Add(new SubLocal<TComp, TEvent>());
+            _subscriptions.Add(new SubComp<TComp, TEvent>());
         }
 
         protected void SubscribeComponent<TComp, TEvent>(
@@ -72,7 +72,29 @@ namespace OpenNefia.Core.GameObjects
             EntityManager.EventBus.SubscribeComponentEvent(handler, priority);
 
             _subscriptions ??= new();
-            _subscriptions.Add(new SubLocal<TComp, TEvent>());
+            _subscriptions.Add(new SubEntity<TEvent>());
+        }
+
+        protected void SubscribeEntity<TEvent>(
+            EntityEventHandler<TEvent> handler,
+            long priority = EventPriorities.Default)
+            where TEvent : notnull
+        {
+            EntityManager.EventBus.SubscribeEntityEvent(handler, priority);
+
+            _subscriptions ??= new();
+            _subscriptions.Add(new SubEntity<TEvent>());
+        }
+
+        protected void SubscribeEntity<TEvent>(
+            EntityEventRefHandler<TEvent> handler,
+            long priority = EventPriorities.Default)
+            where TEvent : notnull
+        {
+            EntityManager.EventBus.SubscribeEntityEvent(handler, priority);
+
+            _subscriptions ??= new();
+            _subscriptions.Add(new SubEntity<TEvent>());
         }
 
         private void ShutdownSubscriptions()
@@ -136,11 +158,19 @@ namespace OpenNefia.Core.GameObjects
             }
         }
 
-        private sealed class SubLocal<TComp, TBase> : SubBase where TComp : IComponent where TBase : notnull
+        private sealed class SubComp<TComp, TBase> : SubBase where TComp : IComponent where TBase : notnull
         {
             public override void Unsubscribe(EntitySystem sys, IEventBus bus)
             {
                 bus.UnsubscribeAllComponentEvents<TComp, TBase>();
+            }
+        }
+
+        private sealed class SubEntity<TBase> : SubBase where TBase : notnull
+        {
+            public override void Unsubscribe(EntitySystem sys, IEventBus bus)
+            {
+                bus.UnsubscribeAllEntityEvents<TBase>();
             }
         }
     }

--- a/OpenNefia.Core/GameObjects/EntitySystem.Subscriptions.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystem.Subscriptions.cs
@@ -158,7 +158,7 @@ namespace OpenNefia.Core.GameObjects
         {
             public override void Unsubscribe(EntitySystem sys, IEventBus bus)
             {
-                bus.UnsubscribeLocalEvent<TComp, TBase>();
+                bus.UnsubscribeAllLocalEvents<TComp, TBase>();
             }
         }
     }

--- a/OpenNefia.Core/GameObjects/EntitySystem.Subscriptions.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystem.Subscriptions.cs
@@ -13,71 +13,63 @@ namespace OpenNefia.Core.GameObjects
         /// </summary>
         protected Subscriptions Subs { get; }
 
-        protected void SubscribeLocalEvent<T>(
-            EntityEventHandler<T> handler,
+        protected void SubscribeBroadcast<T>(
+            BroadcastEventHandler<T> handler,
             long priority = EventPriorities.Default)
             where T : notnull
         {
-            SubEvent(handler, priority);
+            SubBroadcastEvent(handler, priority);
         }
 
-        protected void SubscribeLocalEvent<T>(
-            EntityEventRefHandler<T> handler,
+        protected void SubscribeBroadcast<T>(
+            BroadcastEventRefHandler<T> handler,
             long priority = EventPriorities.Default)
             where T : notnull
         {
-            SubEvent(handler, priority);
+            SubBroadcastEvent(handler, priority);
         }
 
-        protected void SubscribeAllEvent<T>(
-            EntityEventHandler<T> handler,
+        private void SubBroadcastEvent<T>(
+            BroadcastEventHandler<T> handler,
             long priority = EventPriorities.Default)
             where T : notnull
         {
-            SubEvent(handler, priority);
-        }
-
-        private void SubEvent<T>(
-            EntityEventHandler<T> handler,
-            long priority = EventPriorities.Default)
-            where T : notnull
-        {
-            EntityManager.EventBus.SubscribeEvent(this, handler, priority);
+            EntityManager.EventBus.SubscribeBroadcastEvent(this, handler, priority);
 
             _subscriptions ??= new();
             _subscriptions.Add(new SubBroadcast<T>());
         }
 
-        private void SubEvent<T>(
-            EntityEventRefHandler<T> handler,
+        private void SubBroadcastEvent<T>(
+            BroadcastEventRefHandler<T> handler,
             long priority = EventPriorities.Default)
             where T : notnull
         {
-            EntityManager.EventBus.SubscribeEvent(this, handler, priority);
+            EntityManager.EventBus.SubscribeBroadcastEvent(this, handler, priority);
 
             _subscriptions ??= new();
             _subscriptions.Add(new SubBroadcast<T>());
         }
 
-        protected void SubscribeLocalEvent<TComp, TEvent>(
+        protected void SubscribeComponent<TComp, TEvent>(
             ComponentEventHandler<TComp, TEvent> handler,
             long priority = EventPriorities.Default)
             where TComp : IComponent
             where TEvent : notnull
         {
-            EntityManager.EventBus.SubscribeLocalEvent(handler, priority);
+            EntityManager.EventBus.SubscribeComponentEvent(handler, priority);
 
             _subscriptions ??= new();
             _subscriptions.Add(new SubLocal<TComp, TEvent>());
         }
 
-        protected void SubscribeLocalEvent<TComp, TEvent>(
+        protected void SubscribeComponent<TComp, TEvent>(
             ComponentEventRefHandler<TComp, TEvent> handler,
             long priority = EventPriorities.Default)
             where TComp : IComponent
             where TEvent : notnull
         {
-            EntityManager.EventBus.SubscribeLocalEvent(handler, priority);
+            EntityManager.EventBus.SubscribeComponentEvent(handler, priority);
 
             _subscriptions ??= new();
             _subscriptions.Add(new SubLocal<TComp, TEvent>());
@@ -113,12 +105,12 @@ namespace OpenNefia.Core.GameObjects
 
             // Intended for helper methods, so minimal API.
 
-            public void SubEvent<T>(
-                EntityEventHandler<T> handler,
+            public void SubBroadcast<T>(
+                BroadcastEventHandler<T> handler,
                 long priority = EventPriorities.Default)
                 where T : notnull
             {
-                System.SubEvent(handler, priority);
+                System.SubBroadcastEvent(handler, priority);
             }
 
             public void SubscribeLocalEvent<TComp, TEvent>(
@@ -127,7 +119,7 @@ namespace OpenNefia.Core.GameObjects
                 where TComp : IComponent
                 where TEvent : EntityEventArgs
             {
-                System.SubscribeLocalEvent(handler, priority);
+                System.SubscribeComponent(handler, priority);
             }
         }
 
@@ -148,7 +140,7 @@ namespace OpenNefia.Core.GameObjects
         {
             public override void Unsubscribe(EntitySystem sys, IEventBus bus)
             {
-                bus.UnsubscribeAllLocalEvents<TComp, TBase>();
+                bus.UnsubscribeAllComponentEvents<TComp, TBase>();
             }
         }
     }

--- a/OpenNefia.Core/GameObjects/EntitySystem.Subscriptions.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystem.Subscriptions.cs
@@ -18,7 +18,7 @@ namespace OpenNefia.Core.GameObjects
             long priority = EventPriorities.Default)
             where T : notnull
         {
-            SubEvent(EventSource.Local, handler, priority);
+            SubEvent(handler, priority);
         }
 
         protected void SubscribeLocalEvent<T>(
@@ -26,7 +26,7 @@ namespace OpenNefia.Core.GameObjects
             long priority = EventPriorities.Default)
             where T : notnull
         {
-            SubEvent(EventSource.Local, handler, priority);
+            SubEvent(handler, priority);
         }
 
         protected void SubscribeAllEvent<T>(
@@ -34,31 +34,29 @@ namespace OpenNefia.Core.GameObjects
             long priority = EventPriorities.Default)
             where T : notnull
         {
-            SubEvent(EventSource.All, handler, priority);
+            SubEvent(handler, priority);
         }
 
         private void SubEvent<T>(
-            EventSource src,
             EntityEventHandler<T> handler,
             long priority = EventPriorities.Default)
             where T : notnull
         {
-            EntityManager.EventBus.SubscribeEvent(src, this, handler, priority);
+            EntityManager.EventBus.SubscribeEvent(this, handler, priority);
 
             _subscriptions ??= new();
-            _subscriptions.Add(new SubBroadcast<T>(src));
+            _subscriptions.Add(new SubBroadcast<T>());
         }
 
         private void SubEvent<T>(
-            EventSource src,
             EntityEventRefHandler<T> handler,
             long priority = EventPriorities.Default)
             where T : notnull
         {
-            EntityManager.EventBus.SubscribeEvent(src, this, handler, priority);
+            EntityManager.EventBus.SubscribeEvent(this, handler, priority);
 
             _subscriptions ??= new();
-            _subscriptions.Add(new SubBroadcast<T>(src));
+            _subscriptions.Add(new SubBroadcast<T>());
         }
 
         protected void SubscribeLocalEvent<TComp, TEvent>(
@@ -116,12 +114,11 @@ namespace OpenNefia.Core.GameObjects
             // Intended for helper methods, so minimal API.
 
             public void SubEvent<T>(
-                EventSource src,
                 EntityEventHandler<T> handler,
                 long priority = EventPriorities.Default)
                 where T : notnull
             {
-                System.SubEvent(src, handler, priority);
+                System.SubEvent(handler, priority);
             }
 
             public void SubscribeLocalEvent<TComp, TEvent>(
@@ -141,16 +138,9 @@ namespace OpenNefia.Core.GameObjects
 
         private sealed class SubBroadcast<T> : SubBase where T : notnull
         {
-            private readonly EventSource _source;
-
-            public SubBroadcast(EventSource source)
-            {
-                _source = source;
-            }
-
             public override void Unsubscribe(EntitySystem sys, IEventBus bus)
             {
-                bus.UnsubscribeEvent<T>(_source, sys);
+                bus.UnsubscribeEvent<T>(sys);
             }
         }
 

--- a/OpenNefia.Core/GameObjects/EntitySystem.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystem.cs
@@ -59,23 +59,23 @@ namespace OpenNefia.Core.GameObjects
         protected void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
             where TEvent : notnull
         {
-            EntityManager.EventBus.RaiseLocalEvent(uid, args, broadcast);
+            EntityManager.EventBus.RaiseEvent(uid, args, broadcast);
         }
 
         protected void RaiseLocalEvent(EntityUid uid, object args, bool broadcast = true)
         {
-            EntityManager.EventBus.RaiseLocalEvent(uid, args, broadcast);
+            EntityManager.EventBus.RaiseEvent(uid, args, broadcast);
         }
 
         protected void RaiseLocalEvent<TEvent>(EntityUid uid, ref TEvent args, bool broadcast = true)
             where TEvent : notnull
         {
-            EntityManager.EventBus.RaiseLocalEvent(uid, ref args, broadcast);
+            EntityManager.EventBus.RaiseEvent(uid, ref args, broadcast);
         }
 
         protected void RaiseLocalEvent(EntityUid uid, ref object args, bool broadcast = true)
         {
-            EntityManager.EventBus.RaiseLocalEvent(uid, ref args, broadcast);
+            EntityManager.EventBus.RaiseEvent(uid, ref args, broadcast);
         }
 
         #endregion

--- a/OpenNefia.Core/GameObjects/EntitySystem.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystem.cs
@@ -46,34 +46,34 @@ namespace OpenNefia.Core.GameObjects
 
         #region Event Proxy
 
-        protected void RaiseLocalEvent<T>(T message) where T : notnull
+        protected void RaiseEvent<T>(T message) where T : notnull
         {
             EntityManager.EventBus.RaiseEvent(message);
         }
 
-        protected void RaiseLocalEvent(object message)
+        protected void RaiseEvent(object message)
         {
             EntityManager.EventBus.RaiseEvent(message);
         }
 
-        protected void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
+        protected void RaiseEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)
             where TEvent : notnull
         {
             EntityManager.EventBus.RaiseEvent(uid, args, broadcast);
         }
 
-        protected void RaiseLocalEvent(EntityUid uid, object args, bool broadcast = true)
+        protected void RaiseEvent(EntityUid uid, object args, bool broadcast = true)
         {
             EntityManager.EventBus.RaiseEvent(uid, args, broadcast);
         }
 
-        protected void RaiseLocalEvent<TEvent>(EntityUid uid, ref TEvent args, bool broadcast = true)
+        protected void RaiseEvent<TEvent>(EntityUid uid, ref TEvent args, bool broadcast = true)
             where TEvent : notnull
         {
             EntityManager.EventBus.RaiseEvent(uid, ref args, broadcast);
         }
 
-        protected void RaiseLocalEvent(EntityUid uid, ref object args, bool broadcast = true)
+        protected void RaiseEvent(EntityUid uid, ref object args, bool broadcast = true)
         {
             EntityManager.EventBus.RaiseEvent(uid, ref args, broadcast);
         }

--- a/OpenNefia.Core/GameObjects/EntitySystem.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystem.cs
@@ -48,12 +48,12 @@ namespace OpenNefia.Core.GameObjects
 
         protected void RaiseLocalEvent<T>(T message) where T : notnull
         {
-            EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
+            EntityManager.EventBus.RaiseEvent(message);
         }
 
         protected void RaiseLocalEvent(object message)
         {
-            EntityManager.EventBus.RaiseEvent(EventSource.Local, message);
+            EntityManager.EventBus.RaiseEvent(message);
         }
 
         protected void RaiseLocalEvent<TEvent>(EntityUid uid, TEvent args, bool broadcast = true)

--- a/OpenNefia.Core/GameObjects/EntitySystems/EntityLookup.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystems/EntityLookup.cs
@@ -129,7 +129,7 @@ namespace OpenNefia.Core.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<MapComponent, MapCreatedEvent>(HandleMapCreated);
+            SubscribeComponent<MapComponent, MapCreatedEvent>(HandleMapCreated);
         }
 
         private void HandleMapCreated(EntityUid uid, MapComponent component, MapCreatedEvent args)

--- a/OpenNefia.Core/GameObjects/EntitySystems/MoveableSystem.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystems/MoveableSystem.cs
@@ -19,7 +19,7 @@ namespace OpenNefia.Core.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<MoveableComponent, MoveEventArgs>(HandleMove);
+            SubscribeComponent<MoveableComponent, MoveEventArgs>(HandleMove);
         }
 
         #region Methods

--- a/OpenNefia.Core/GameObjects/EntitySystems/MoveableSystem.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystems/MoveableSystem.cs
@@ -33,7 +33,7 @@ namespace OpenNefia.Core.GameObjects
 
             var oldPosition = spatial.MapPosition;
             var ev = new MoveEventArgs(oldPosition, newPosition);
-            RaiseLocalEvent(entity, ev);
+            RaiseEvent(entity, ev);
             return ev.TurnResult;
         }
 
@@ -81,7 +81,7 @@ namespace OpenNefia.Core.GameObjects
             spatial.WorldPosition = newCoords.Position;
 
             var evAfter = new AfterMoveEventArgs(oldCoords, newCoords);
-            RaiseLocalEvent(uid, evAfter);
+            RaiseEvent(uid, evAfter);
 
             return TurnResult.Succeeded;
         }

--- a/OpenNefia.Core/GameObjects/EntitySystems/SpatialSystem.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystems/SpatialSystem.cs
@@ -17,11 +17,11 @@ namespace OpenNefia.Core.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<SpatialComponent, EntityPositionChangedEvent>(HandlePositionChanged);
-            SubscribeLocalEvent<SpatialComponent, EntityMapInitEvent>(HandleMapInit);
-            SubscribeLocalEvent<SpatialComponent, EntityLivenessChangedEvent>(HandleLivenessChanged);
-            SubscribeLocalEvent<SpatialComponent, EntityTerminatingEvent>(HandleEntityTerminating);
-            SubscribeLocalEvent<SpatialComponent, EntityTangibilityChangedEvent>(HandleTangibilityChanged);
+            SubscribeComponent<SpatialComponent, EntityPositionChangedEvent>(HandlePositionChanged);
+            SubscribeComponent<SpatialComponent, EntityMapInitEvent>(HandleMapInit);
+            SubscribeComponent<SpatialComponent, EntityLivenessChangedEvent>(HandleLivenessChanged);
+            SubscribeComponent<SpatialComponent, EntityTerminatingEvent>(HandleEntityTerminating);
+            SubscribeComponent<SpatialComponent, EntityTangibilityChangedEvent>(HandleTangibilityChanged);
         }
 
         /// <summary>

--- a/OpenNefia.Core/GameObjects/EntitySystems/StackSystem.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystems/StackSystem.cs
@@ -148,12 +148,12 @@ namespace OpenNefia.Core.GameObjects
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<StackComponent, EntityMapInitEvent>(HandleEntityInitialized);
-            SubscribeLocalEvent<StackComponent, StackCountChangedEvent>(HandleStackCountChanged);
+            SubscribeComponent<StackComponent, EntityMapInitEvent>(HandleEntityInitialized);
+            SubscribeComponent<StackComponent, StackCountChangedEvent>(HandleStackCountChanged);
 
-            SubscribeLocalEvent<SpatialComponent, EntityClonedEventArgs>(HandleCloneSpatial);
-            SubscribeLocalEvent<MetaDataComponent, EntityClonedEventArgs>(HandleCloneMetaData);
-            SubscribeLocalEvent<StackComponent, EntityClonedEventArgs>(HandleCloneStack);
+            SubscribeComponent<SpatialComponent, EntityClonedEventArgs>(HandleCloneSpatial);
+            SubscribeComponent<MetaDataComponent, EntityClonedEventArgs>(HandleCloneMetaData);
+            SubscribeComponent<StackComponent, EntityClonedEventArgs>(HandleCloneStack);
         }
 
         private void HandleEntityInitialized(EntityUid uid, StackComponent stackable, ref EntityMapInitEvent args)

--- a/OpenNefia.Core/GameObjects/EntitySystems/StackSystem.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystems/StackSystem.cs
@@ -218,7 +218,7 @@ namespace OpenNefia.Core.GameObjects
 
             stack.Count = amount;
 
-            RaiseLocalEvent(uid, new StackCountChangedEvent(old, stack.Count), false);
+            RaiseEvent(uid, new StackCountChangedEvent(old, stack.Count), false);
         }
 
         /// <inheritdoc/>
@@ -294,7 +294,7 @@ namespace OpenNefia.Core.GameObjects
             var newCount = stackTarget.Count + stackWith.Count;
 
             var ev = new EntityStackedEvent(with, stackTarget.Count, newCount, showMessage);
-            RaiseLocalEvent(target, ref ev);
+            RaiseEvent(target, ref ev);
 
             SetCount(target, newCount, stackTarget);
             SetCount(with, 0, stackWith);
@@ -383,14 +383,14 @@ namespace OpenNefia.Core.GameObjects
             var newEntity = EntityManager.SpawnEntity(null, spawnPosition);
 
             var args = new EntityClonedEventArgs(newEntity);
-            RaiseLocalEvent(target, args);
+            RaiseEvent(target, args);
 
             CopyComponents(newEntity, target, args);
 
             _entityFactory.LocalizeComponents(newEntity);
 
             var ev = new EntityCloneFinishedEventArgs(target);
-            RaiseLocalEvent(newEntity, ev);
+            RaiseEvent(newEntity, ev);
 
             return newEntity;
         }
@@ -474,7 +474,7 @@ namespace OpenNefia.Core.GameObjects
             }
 
             var ev = new EntitySplitEvent(split);
-            RaiseLocalEvent(uid, ref ev);
+            RaiseEvent(uid, ref ev);
 
             return true;
         }

--- a/OpenNefia.Core/GameObjects/EntitySystems/VerbSystem.cs
+++ b/OpenNefia.Core/GameObjects/EntitySystems/VerbSystem.cs
@@ -30,7 +30,7 @@ namespace OpenNefia.Core.GameObjects
             var verbs = new SortedSet<Verb>();
 
             var getVerbsEvent = new GetVerbsEventArgs(source, target);
-            RaiseLocalEvent(target, getVerbsEvent);
+            RaiseEvent(target, getVerbsEvent);
             verbs.AddRange(getVerbsEvent.Verbs);
 
             return verbs;
@@ -42,7 +42,7 @@ namespace OpenNefia.Core.GameObjects
         public TurnResult ExecuteVerb(EntityUid source, EntityUid target, Verb verb)
         {
             var ev = new ExecuteVerbEventArgs(source, target, verb);
-            RaiseLocalEvent(source, ev);
+            RaiseEvent(source, ev);
             return ev.TurnResult;
         }
     }

--- a/OpenNefia.Core/GameObjects/MapInitExt.cs
+++ b/OpenNefia.Core/GameObjects/MapInitExt.cs
@@ -26,7 +26,7 @@ namespace OpenNefia.Core.GameObjects
             meta.EntityLifeStage = EntityLifeStage.MapInitialized;
 
             var ev = new EntityMapInitEvent();
-            entMan.EventBus.RaiseLocalEvent(entity, ref ev, false);
+            entMan.EventBus.RaiseEvent(entity, ref ev, false);
         }
     }
 }

--- a/OpenNefia.Core/Maps/Loader/Context/MapDeserializer.cs
+++ b/OpenNefia.Core/Maps/Loader/Context/MapDeserializer.cs
@@ -359,7 +359,7 @@ namespace OpenNefia.Core.Maps
             // at that point.
             // Maybe run initialize/startup for just the map entity first?
             var ev = new MapCreatedEvent(MapGrid!, loadedFromSave: true);
-            _entityManager.EventBus.RaiseLocalEvent(MapGrid!.MapEntityUid, ev);
+            _entityManager.EventBus.RaiseEvent(MapGrid!.MapEntityUid, ev);
 
             foreach (var entityUid in _context.Entities)
             {

--- a/OpenNefia.Core/Maps/MapManager.cs
+++ b/OpenNefia.Core/Maps/MapManager.cs
@@ -168,7 +168,7 @@ namespace OpenNefia.Core.Maps
                 Logger.DebugS("map", $"Binding map {actualID} to entity {newEnt}");
 
                 var ev = new MapCreatedEvent(map, loadedFromSave: false);
-                _entityManager.EventBus.RaiseLocalEvent(map.MapEntityUid, ev);
+                _entityManager.EventBus.RaiseEvent(map.MapEntityUid, ev);
 
                 return newEnt;
             }
@@ -299,7 +299,7 @@ namespace OpenNefia.Core.Maps
             map.LastSightId++;
 
             var ev = new RefreshMapVisibilityEvent(map);
-            IoCManager.Resolve<IEntityManager>().EventBus.RaiseLocalEvent(map.MapEntityUid, ref ev);
+            IoCManager.Resolve<IEntityManager>().EventBus.RaiseEvent(map.MapEntityUid, ref ev);
 
             var outOfSightCoords = map.MapObjectMemory.AllMemory.Values
                 .Where(memory => memory.HideWhenOutOfSight && !map.IsInWindowFov(memory.Coords.Position))

--- a/OpenNefia.Core/Maps/MapSystem.cs
+++ b/OpenNefia.Core/Maps/MapSystem.cs
@@ -22,7 +22,7 @@ namespace OpenNefia.Core.Maps
         private void OnActiveMapChanged(IMap map, IMap? oldMap, MapLoadType loadType)
         {
             var ev = new ActiveMapChangedEvent(map, oldMap, loadType);
-            RaiseLocalEvent(map.MapEntityUid, ev);
+            RaiseEvent(map.MapEntityUid, ev);
         }
 
         private void OnMapAdd(EntityUid uid, MapComponent component, ComponentAdd args)

--- a/OpenNefia.Core/Maps/MapSystem.cs
+++ b/OpenNefia.Core/Maps/MapSystem.cs
@@ -14,9 +14,9 @@ namespace OpenNefia.Core.Maps
 
             _mapManager.OnActiveMapChanged += OnActiveMapChanged;
 
-            SubscribeLocalEvent<MapComponent, ComponentAdd>(OnMapAdd);
-            SubscribeLocalEvent<MapComponent, ComponentInit>(OnMapInit);
-            SubscribeLocalEvent<MapComponent, ComponentStartup>(OnMapStartup);
+            SubscribeComponent<MapComponent, ComponentAdd>(OnMapAdd);
+            SubscribeComponent<MapComponent, ComponentInit>(OnMapInit);
+            SubscribeComponent<MapComponent, ComponentStartup>(OnMapStartup);
         }
 
         private void OnActiveMapChanged(IMap map, IMap? oldMap, MapLoadType loadType)
@@ -28,19 +28,19 @@ namespace OpenNefia.Core.Maps
         private void OnMapAdd(EntityUid uid, MapComponent component, ComponentAdd args)
         {
             var msg = new MapComponentAddEvent(uid, component.MapId);
-            EntityManager.EventBus.RaiseLocalEvent(uid, msg);
+            EntityManager.EventBus.RaiseEvent(uid, msg);
         }
 
         private void OnMapInit(EntityUid uid, MapComponent component, ComponentInit args)
         {
             var msg = new MapComponentInitializeEvent(uid, component.MapId);
-            EntityManager.EventBus.RaiseLocalEvent(uid, msg);
+            EntityManager.EventBus.RaiseEvent(uid, msg);
         }
 
         private void OnMapStartup(EntityUid uid, MapComponent component, ComponentStartup args)
         {
             var msg = new MapComponentStartupEvent(uid, component.MapId);
-            EntityManager.EventBus.RaiseLocalEvent(uid, msg);
+            EntityManager.EventBus.RaiseEvent(uid, msg);
         }
     }
 

--- a/OpenNefia.Core/Rendering/MapObjectMemoryStore.cs
+++ b/OpenNefia.Core/Rendering/MapObjectMemoryStore.cs
@@ -138,7 +138,7 @@ namespace OpenNefia.Core.Rendering
                 var memory = GetOrCreateMemory();
 
                 _event.Memory = memory;
-                entityManager.EventBus.RaiseLocalEvent(spatial.Owner, _event);
+                entityManager.EventBus.RaiseEvent(spatial.Owner, _event);
                 memory = _event.Memory;
 
                 if (at == null)

--- a/OpenNefia.LecchoTorte/LivingWall/LivingWallSystem.cs
+++ b/OpenNefia.LecchoTorte/LivingWall/LivingWallSystem.cs
@@ -15,9 +15,9 @@ namespace OpenNefia.LecchoTorte.LivingWall
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<LivingWallComponent, EntityPositionChangedEvent>(HandlePositionChanged);
-            SubscribeLocalEvent<LivingWallComponent, EntityMapInitEvent>(HandleMapInit);
-            SubscribeLocalEvent<LivingWallComponent, EntityLivenessChangedEvent>(HandleLivenessChanged);
+            SubscribeComponent<LivingWallComponent, EntityPositionChangedEvent>(HandlePositionChanged);
+            SubscribeComponent<LivingWallComponent, EntityMapInitEvent>(HandleMapInit);
+            SubscribeComponent<LivingWallComponent, EntityLivenessChangedEvent>(HandleLivenessChanged);
         }
 
         private void HandleMapInit(EntityUid uid, LivingWallComponent component, ref EntityMapInitEvent args)

--- a/OpenNefia.LecchoTorte/QuickStart/QuickStartSystem.cs
+++ b/OpenNefia.LecchoTorte/QuickStart/QuickStartSystem.cs
@@ -24,7 +24,7 @@ namespace OpenNefia.LecchoTorte.QuickStart
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<NewGameStartedEventArgs>(HandleNewGame);
+            SubscribeBroadcast<NewGameStartedEventArgs>(HandleNewGame);
         }
 
         private void HandleNewGame(NewGameStartedEventArgs ev)

--- a/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.BroadcastEvent.cs
+++ b/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.BroadcastEvent.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Moq;
+using NUnit.Framework;
+using OpenNefia.Core.GameObjects;
+
+namespace OpenNefia.Tests.Core.GameObjects
+{
+    public partial class EntityEventBusTests
+    {
+        [Test]
+        public void SubscribeBroadcastEvent()
+        {
+            // Arrange
+            var entUid = new EntityUid(7);
+
+            var entManMock = new Mock<IEntityManager>();
+
+            var bus = new EntityEventBus(entManMock.Object);
+
+            // Subscribe
+            var calledCount = 0;
+            var subscriber = new DummyEventSubscriber();
+
+            bus.SubscribeBroadcastEvent<TestEvent>(subscriber, HandleTestEvent);
+
+            // Raise
+            var eventArgs = new TestEvent(5);
+            bus.RaiseEvent(entUid, eventArgs);
+
+            // Assert
+            Assert.That(calledCount, Is.EqualTo(1));
+            void HandleTestEvent(TestEvent args)
+            {
+                calledCount++;
+                Assert.That(args.TestNumber, Is.EqualTo(5));
+            }
+        }
+
+        [Test]
+        public void CompAndBroadcastEventsOrdered()
+        {
+            // Arrange
+            var entUid = new EntityUid(7);
+
+            var entManMock = new Mock<IEntityManager>();
+            var compFacMock = new Mock<IComponentFactory>();
+
+            void Setup<T>(out T instance) where T : IComponent, new()
+            {
+                IComponent? inst = instance = new T();
+                var reg = new Mock<IComponentRegistration>();
+                reg.Setup(m => m.References).Returns(new Type[] { typeof(T) });
+
+                compFacMock.Setup(m => m.GetRegistration(typeof(T))).Returns(reg.Object);
+                entManMock.Setup(m => m.TryGetComponent(entUid, typeof(T), out inst)).Returns(true);
+                entManMock.Setup(m => m.GetComponent(entUid, typeof(T))).Returns(inst);
+            }
+
+            Setup<OrderComponentA>(out var instA);
+            Setup<OrderComponentB>(out var instB);
+
+            entManMock.Setup(m => m.ComponentFactory).Returns(compFacMock.Object);
+            var bus = new EntityEventBus(entManMock.Object);
+
+            // Subscribe
+            var a = false;
+            var broadcast = false;
+            var b = false;
+
+            void HandlerA(EntityUid uid, Component comp, TestEvent ev)
+            {
+                Assert.That(b, Is.False, "A should run before B");
+                Assert.That(broadcast, Is.True, "A should run after broadcast");
+
+                a = true;
+            }
+
+            void HandlerBroadcast(TestEvent ev)
+            {
+                Assert.That(a, Is.False, "Broadcast should run before A");
+                Assert.That(b, Is.False, "Broadcast should run before B");
+                broadcast = true;
+            }
+
+            void HandlerB(EntityUid uid, Component comp, TestEvent ev)
+            {
+                Assert.That(a, Is.True, "B should run after A");
+                Assert.That(broadcast, Is.True, "B should run after broadcast");
+                b = true;
+            }
+
+            var subscriber = new DummyEventSubscriber();
+
+            bus.SubscribeComponentEvent<OrderComponentA, TestEvent>(HandlerA, EventPriorities.High);
+            bus.SubscribeBroadcastEvent<TestEvent>(subscriber, HandlerBroadcast, EventPriorities.VeryHigh);
+            bus.SubscribeComponentEvent<OrderComponentB, TestEvent>(HandlerB, EventPriorities.VeryLow);
+
+            // add a component to the system
+            entManMock.Raise(m => m.EntityAdded += null, entManMock.Object, entUid);
+            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(instA, entUid));
+            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(instB, entUid));
+
+            // Raise
+            var evntArgs = new TestEvent(5);
+            bus.RaiseEvent(entUid, evntArgs);
+
+            // Assert
+            Assert.That(a, Is.True, "A did not fire");
+            Assert.That(broadcast, Is.True, "Broadcast did not fire");
+            Assert.That(b, Is.True, "B did not fire");
+        }
+    }
+}

--- a/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.ComponentEvent.cs
+++ b/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.ComponentEvent.cs
@@ -294,7 +294,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             var subscriber = new DummyEventSubscriber();
 
             bus.SubscribeLocalEvent<OrderComponentA, TestEvent>(HandlerA, EventPriorities.High);
-            bus.SubscribeEvent<TestEvent>(EventSource.Local, subscriber, HandlerBroadcast, EventPriorities.VeryHigh);
+            bus.SubscribeEvent<TestEvent>(subscriber, HandlerBroadcast, EventPriorities.VeryHigh);
             bus.SubscribeLocalEvent<OrderComponentB, TestEvent>(HandlerB, EventPriorities.VeryLow);
 
             // add a component to the system
@@ -327,7 +327,7 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             var subscriber = new DummyEventSubscriber();
 
-            bus.SubscribeEvent<TestEvent>(EventSource.Local, subscriber, _ => broadcast = true, EventPriorities.VeryHigh);
+            bus.SubscribeEvent<TestEvent>(subscriber, _ => broadcast = true, EventPriorities.VeryHigh);
 
             // Raise
             var evntArgs = new TestEvent(5);

--- a/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.ComponentEvent.cs
+++ b/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.ComponentEvent.cs
@@ -37,7 +37,7 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             // Subscribe
             int calledCount = 0;
-            bus.SubscribeLocalEvent<MetaDataComponent, TestEvent>(HandleTestEvent);
+            bus.SubscribeComponentEvent<MetaDataComponent, TestEvent>(HandleTestEvent);
 
             // add a component to the system
             entManMock.Raise(m=>m.EntityAdded += null, entManMock.Object, entUid);
@@ -45,7 +45,7 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             // Raise
             var evntArgs = new TestEvent(5);
-            bus.RaiseLocalEvent(entUid, evntArgs);
+            bus.RaiseEvent(entUid, evntArgs);
 
             // Assert
             Assert.That(calledCount, Is.EqualTo(1));
@@ -86,8 +86,8 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             // Subscribe
             int calledCount = 0;
-            bus.SubscribeLocalEvent<MetaDataComponent, TestEvent>(HandleTestEvent);
-            bus.UnsubscribeAllLocalEvents<MetaDataComponent, TestEvent>();
+            bus.SubscribeComponentEvent<MetaDataComponent, TestEvent>(HandleTestEvent);
+            bus.UnsubscribeAllComponentEvents<MetaDataComponent, TestEvent>();
 
             // add a component to the system
             entManMock.Raise(m => m.EntityAdded += null, entManMock.Object, entUid);
@@ -95,7 +95,7 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             // Raise
             var evntArgs = new TestEvent(5);
-            bus.RaiseLocalEvent(entUid, evntArgs);
+            bus.RaiseEvent(entUid, evntArgs);
 
             // Assert
             Assert.That(calledCount, Is.EqualTo(0));
@@ -135,14 +135,14 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             // Subscribe
             int calledCount = 0;
-            bus.SubscribeLocalEvent<MetaDataComponent, ComponentInit>(HandleTestEvent);
+            bus.SubscribeComponentEvent<MetaDataComponent, ComponentInit>(HandleTestEvent);
 
             // add a component to the system
             entManMock.Raise(m=>m.EntityAdded += null, entManMock.Object, entUid);
             entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(compInstance, entUid));
 
             // Raise
-            ((IEventBus)bus).RaiseComponentEvent(compInstance, new ComponentInit());
+            ((IEventBus)bus).RaiseDirectedComponentEvent(compInstance, new ComponentInit());
 
             // Assert
             Assert.That(calledCount, Is.EqualTo(1));
@@ -213,10 +213,10 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             void HandlerC(EntityUid uid, Component comp, TestEvent ev) => c = true;
 
-            bus.SubscribeLocalEvent<OrderComponentA, TestEvent>(HandlerA, EventPriorities.Highest);
-            bus.SubscribeLocalEvent<OrderComponentB, TestEvent>(HandlerB);
-            bus.SubscribeLocalEvent<OrderComponentC, TestEvent>(HandlerC, EventPriorities.High);
-            bus.SubscribeLocalEvent<OrderComponentC2, TestEvent>(HandlerC2, EventPriorities.Low);
+            bus.SubscribeComponentEvent<OrderComponentA, TestEvent>(HandlerA, EventPriorities.Highest);
+            bus.SubscribeComponentEvent<OrderComponentB, TestEvent>(HandlerB);
+            bus.SubscribeComponentEvent<OrderComponentC, TestEvent>(HandlerC, EventPriorities.High);
+            bus.SubscribeComponentEvent<OrderComponentC2, TestEvent>(HandlerC2, EventPriorities.Low);
 
             // add a component to the system
             entManMock.Raise(m=>m.EntityAdded += null, entManMock.Object, entUid);
@@ -227,7 +227,7 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             // Raise
             var evntArgs = new TestEvent(5);
-            bus.RaiseLocalEvent(entUid, evntArgs);
+            bus.RaiseEvent(entUid, evntArgs);
 
             // Assert
             Assert.That(a, Is.True, "A did not fire");
@@ -293,9 +293,9 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             var subscriber = new DummyEventSubscriber();
 
-            bus.SubscribeLocalEvent<OrderComponentA, TestEvent>(HandlerA, EventPriorities.High);
-            bus.SubscribeEvent<TestEvent>(subscriber, HandlerBroadcast, EventPriorities.VeryHigh);
-            bus.SubscribeLocalEvent<OrderComponentB, TestEvent>(HandlerB, EventPriorities.VeryLow);
+            bus.SubscribeComponentEvent<OrderComponentA, TestEvent>(HandlerA, EventPriorities.High);
+            bus.SubscribeBroadcastEvent<TestEvent>(subscriber, HandlerBroadcast, EventPriorities.VeryHigh);
+            bus.SubscribeComponentEvent<OrderComponentB, TestEvent>(HandlerB, EventPriorities.VeryLow);
 
             // add a component to the system
             entManMock.Raise(m => m.EntityAdded += null, entManMock.Object, entUid);
@@ -304,7 +304,7 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             // Raise
             var evntArgs = new TestEvent(5);
-            bus.RaiseLocalEvent(entUid, evntArgs);
+            bus.RaiseEvent(entUid, evntArgs);
 
             // Assert
             Assert.That(a, Is.True, "A did not fire");
@@ -327,11 +327,11 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             var subscriber = new DummyEventSubscriber();
 
-            bus.SubscribeEvent<TestEvent>(subscriber, _ => broadcast = true, EventPriorities.VeryHigh);
+            bus.SubscribeBroadcastEvent<TestEvent>(subscriber, _ => broadcast = true, EventPriorities.VeryHigh);
 
             // Raise
             var evntArgs = new TestEvent(5);
-            bus.RaiseLocalEvent(entUid, evntArgs);
+            bus.RaiseEvent(entUid, evntArgs);
 
             // Assert
             Assert.That(broadcast, Is.True, "Broadcast did not fire");
@@ -375,8 +375,8 @@ namespace OpenNefia.Tests.Core.GameObjects
             }
 
             // Subscribe
-            bus.SubscribeLocalEvent<MetaDataComponent, TestEvent>(HandleTestEventA, priority: EventPriorities.Low);
-            bus.SubscribeLocalEvent<MetaDataComponent, TestEvent>(HandleTestEventB);
+            bus.SubscribeComponentEvent<MetaDataComponent, TestEvent>(HandleTestEventA, priority: EventPriorities.Low);
+            bus.SubscribeComponentEvent<MetaDataComponent, TestEvent>(HandleTestEventB);
 
             // add a component to the system
             entManMock.Raise(m => m.EntityAdded += null, entManMock.Object, entUid);
@@ -384,7 +384,7 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             // Raise
             var evntArgs = new TestEvent(5);
-            bus.RaiseLocalEvent(entUid, evntArgs);
+            bus.RaiseEvent(entUid, evntArgs);
 
             // Assert
             Assert.That(a, Is.True, "A did not fire.");

--- a/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.ComponentEvent.cs
+++ b/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.ComponentEvent.cs
@@ -219,7 +219,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             bus.SubscribeComponentEvent<OrderComponentC2, TestEvent>(HandlerC2, EventPriorities.Low);
 
             // add a component to the system
-            entManMock.Raise(m=>m.EntityAdded += null, entManMock.Object, entUid);
+            entManMock.Raise(m => m.EntityAdded += null, entManMock.Object, entUid);
             entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(instA, entUid));
             entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(instB, entUid));
             entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(instC, entUid));
@@ -236,106 +236,6 @@ namespace OpenNefia.Tests.Core.GameObjects
             Assert.That(c2, Is.True, "C2 did not fire");
         }
 
-        [Test]
-        public void CompAndBroadcastEventsOrdered()
-        {
-            // Arrange
-            var entUid = new EntityUid(7);
-
-            var entManMock = new Mock<IEntityManager>();
-            var compFacMock = new Mock<IComponentFactory>();
-
-            void Setup<T>(out T instance) where T : IComponent, new()
-            {
-                IComponent? inst = instance = new T();
-                var reg = new Mock<IComponentRegistration>();
-                reg.Setup(m => m.References).Returns(new Type[] { typeof(T) });
-
-                compFacMock.Setup(m => m.GetRegistration(typeof(T))).Returns(reg.Object);
-                entManMock.Setup(m => m.TryGetComponent(entUid, typeof(T), out inst)).Returns(true);
-                entManMock.Setup(m => m.GetComponent(entUid, typeof(T))).Returns(inst);
-            }
-
-            Setup<OrderComponentA>(out var instA);
-            Setup<OrderComponentB>(out var instB);
-            Setup<OrderComponentC>(out var instC);
-            Setup<OrderComponentC2>(out var instC2);
-
-            entManMock.Setup(m => m.ComponentFactory).Returns(compFacMock.Object);
-            var bus = new EntityEventBus(entManMock.Object);
-
-            // Subscribe
-            var a = false;
-            var broadcast = false;
-            var b = false;
-
-            void HandlerA(EntityUid uid, Component comp, TestEvent ev)
-            {
-                Assert.That(b, Is.False, "A should run before B");
-                Assert.That(broadcast, Is.True, "A should run after broadcast");
-
-                a = true;
-            }
-
-            void HandlerBroadcast(TestEvent ev)
-            {
-                Assert.That(a, Is.False, "Broadcast should run before A");
-                Assert.That(b, Is.False, "Broadcast should run before B");
-                broadcast = true;
-            }
-
-            void HandlerB(EntityUid uid, Component comp, TestEvent ev)
-            {
-                Assert.That(a, Is.True, "B should run after A");
-                Assert.That(broadcast, Is.True, "B should run after broadcast");
-                b = true;
-            }
-
-            var subscriber = new DummyEventSubscriber();
-
-            bus.SubscribeComponentEvent<OrderComponentA, TestEvent>(HandlerA, EventPriorities.High);
-            bus.SubscribeBroadcastEvent<TestEvent>(subscriber, HandlerBroadcast, EventPriorities.VeryHigh);
-            bus.SubscribeComponentEvent<OrderComponentB, TestEvent>(HandlerB, EventPriorities.VeryLow);
-
-            // add a component to the system
-            entManMock.Raise(m => m.EntityAdded += null, entManMock.Object, entUid);
-            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(instA, entUid));
-            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(instB, entUid));
-
-            // Raise
-            var evntArgs = new TestEvent(5);
-            bus.RaiseEvent(entUid, evntArgs);
-
-            // Assert
-            Assert.That(a, Is.True, "A did not fire");
-            Assert.That(broadcast, Is.True, "Broadcast did not fire");
-            Assert.That(b, Is.True, "B did not fire");
-        }
-
-        [Test]
-        public void BroadcastEventsOrdered()
-        {
-            // Arrange
-            var entUid = new EntityUid(7);
-
-            var entManMock = new Mock<IEntityManager>();
-
-            var bus = new EntityEventBus(entManMock.Object);
-
-            // Subscribe
-            var broadcast = false;
-
-            var subscriber = new DummyEventSubscriber();
-
-            bus.SubscribeBroadcastEvent<TestEvent>(subscriber, _ => broadcast = true, EventPriorities.VeryHigh);
-
-            // Raise
-            var evntArgs = new TestEvent(5);
-            bus.RaiseEvent(entUid, evntArgs);
-
-            // Assert
-            Assert.That(broadcast, Is.True, "Broadcast did not fire");
-        }
         [Test]
         public void DuplicateCompEventPairs()
         {

--- a/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.EntityEvent.cs
+++ b/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.EntityEvent.cs
@@ -1,0 +1,113 @@
+using Moq;
+using NUnit.Framework;
+using OpenNefia.Core.GameObjects;
+
+namespace OpenNefia.Tests.Core.GameObjects
+{
+    public partial class EntityEventBusTests
+    {
+        [Test]
+        public void SubscribeEntityEvent()
+        {
+            // Arrange
+            var entUid = new EntityUid(7);
+
+            var entManMock = new Mock<IEntityManager>();
+
+            var bus = new EntityEventBus(entManMock.Object);
+
+            // Subscribe
+            var calledCount = 0;
+
+            bus.SubscribeEntityEvent<TestEvent>(HandleTestEvent);
+
+            // Event tables won't be initialized for an entity unless the entity manager creates it.
+            entManMock.Raise(m => m.EntityAdded += null, entManMock.Object, entUid);
+
+            // Raise
+            var eventArgs = new TestEvent(5);
+            bus.RaiseEvent(entUid, eventArgs);
+
+            // Assert
+            Assert.That(calledCount, Is.EqualTo(1));
+            void HandleTestEvent(EntityUid uid, TestEvent args)
+            {
+                calledCount++;
+                Assert.That(uid, Is.EqualTo(entUid));
+                Assert.That(args.TestNumber, Is.EqualTo(5));
+            }
+        }
+
+        [Test]
+        public void CompAndEntityEventsOrdered()
+        {
+            // Arrange
+            var entUid = new EntityUid(7);
+
+            var entManMock = new Mock<IEntityManager>();
+            var compFacMock = new Mock<IComponentFactory>();
+
+            void Setup<T>(out T instance) where T : IComponent, new()
+            {
+                IComponent? inst = instance = new T();
+                var reg = new Mock<IComponentRegistration>();
+                reg.Setup(m => m.References).Returns(new Type[] { typeof(T) });
+
+                compFacMock.Setup(m => m.GetRegistration(typeof(T))).Returns(reg.Object);
+                entManMock.Setup(m => m.TryGetComponent(entUid, typeof(T), out inst)).Returns(true);
+                entManMock.Setup(m => m.GetComponent(entUid, typeof(T))).Returns(inst);
+            }
+
+            Setup<OrderComponentA>(out var instA);
+            Setup<OrderComponentB>(out var instB);
+
+            entManMock.Setup(m => m.ComponentFactory).Returns(compFacMock.Object);
+            var bus = new EntityEventBus(entManMock.Object);
+
+            // Subscribe
+            var a = false;
+            var entity = false;
+            var b = false;
+
+            void HandlerA(EntityUid uid, Component comp, TestEvent ev)
+            {
+                Assert.That(b, Is.False, "A should run before B");
+                Assert.That(entity, Is.True, "A should run after entity");
+
+                a = true;
+            }
+
+            void HandlerEntity(EntityUid uid, TestEvent ev)
+            {
+                Assert.That(a, Is.False, "Entity should run before A");
+                Assert.That(b, Is.False, "Entity should run before B");
+                entity = true;
+            }
+
+            void HandlerB(EntityUid uid, Component comp, TestEvent ev)
+            {
+                Assert.That(a, Is.True, "B should run after A");
+                Assert.That(entity, Is.True, "B should run after entity");
+                b = true;
+            }
+
+            bus.SubscribeComponentEvent<OrderComponentA, TestEvent>(HandlerA, EventPriorities.High);
+            bus.SubscribeEntityEvent<TestEvent>(HandlerEntity, EventPriorities.VeryHigh);
+            bus.SubscribeComponentEvent<OrderComponentB, TestEvent>(HandlerB, EventPriorities.VeryLow);
+
+            // add a component to the system
+            entManMock.Raise(m => m.EntityAdded += null, entManMock.Object, entUid);
+            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(instA, entUid));
+            entManMock.Raise(m => m.ComponentAdded += null, new AddedComponentEventArgs(instB, entUid));
+
+            // Raise
+            var evntArgs = new TestEvent(5);
+            bus.RaiseEvent(entUid, evntArgs);
+
+            // Assert
+            Assert.That(a, Is.True, "A did not fire");
+            Assert.That(entity, Is.True, "Entity did not fire");
+            Assert.That(b, Is.True, "B did not fire");
+        }
+    }
+}

--- a/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.RefBroadcastEvents.cs
+++ b/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.RefBroadcastEvents.cs
@@ -18,7 +18,7 @@ namespace OpenNefia.Tests.Core.GameObjects
                 .InitializeInstance();
 
             var ev = new TestStructEvent() {TestNumber = 5};
-            simulation.Resolve<IEntityManager>().EventBus.RaiseEvent(EventSource.Local, ref ev);
+            simulation.Resolve<IEntityManager>().EventBus.RaiseEvent(ref ev);
             Assert.That(ev.TestNumber, Is.EqualTo(15));
         }
 
@@ -83,7 +83,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             // Act.
             var testEvent = new TestStructEvent {TestNumber = 5};
             var eventBus = simulation.Resolve<IEntityManager>().EventBus;
-            eventBus.RaiseEvent(EventSource.Local, ref testEvent);
+            eventBus.RaiseEvent(ref testEvent);
 
             // Check that the entity systems changed the value correctly
             Assert.That(testEvent.TestNumber, Is.EqualTo(15));

--- a/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.RefBroadcastEvents.cs
+++ b/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.RefBroadcastEvents.cs
@@ -29,7 +29,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             {
                 base.Initialize();
 
-                SubscribeLocalEvent<TestStructEvent>(OnTestEvent);
+                SubscribeBroadcast<TestStructEvent>(OnTestEvent);
             }
 
             private void OnTestEvent(ref TestStructEvent ev)
@@ -58,8 +58,8 @@ namespace OpenNefia.Tests.Core.GameObjects
             public override void Initialize()
             {
                 // The below is not allowed, as you're subscribing by-ref and by-value to the same event...
-                SubscribeLocalEvent<TestStructEvent>(MyRefHandler);
-                SubscribeLocalEvent<TestStructEvent>(MyValueHandler);
+                SubscribeBroadcast<TestStructEvent>(MyRefHandler);
+                SubscribeBroadcast<TestStructEvent>(MyValueHandler);
             }
 
             private void MyValueHandler(TestStructEvent args) { }
@@ -96,7 +96,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             {
                 base.Initialize();
 
-                SubscribeLocalEvent<TestStructEvent>(OnA);
+                SubscribeBroadcast<TestStructEvent>(OnA);
             }
 
             private void OnA(ref TestStructEvent args)
@@ -114,7 +114,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             {
                 base.Initialize();
 
-                SubscribeLocalEvent<TestStructEvent>(OnB, EventPriorities.Low);
+                SubscribeBroadcast<TestStructEvent>(OnB, EventPriorities.Low);
             }
 
             private void OnB(ref TestStructEvent args)
@@ -132,7 +132,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             {
                 base.Initialize();
 
-                SubscribeLocalEvent<TestStructEvent>(OnC, EventPriorities.High);
+                SubscribeBroadcast<TestStructEvent>(OnC, EventPriorities.High);
             }
 
             private void OnC(ref TestStructEvent args)

--- a/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.RefDirectedEvents.cs
+++ b/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.RefDirectedEvents.cs
@@ -28,7 +28,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             // Act.
             var testEvent = new TestStructEvent {TestNumber = 5};
             var eventBus = simulation.Resolve<IEntityManager>().EventBus;
-            eventBus.RaiseLocalEvent(entity, ref testEvent);
+            eventBus.RaiseEvent(entity, ref testEvent);
 
             // Check that the entity system changed the value correctly
             Assert.That(testEvent.TestNumber, Is.EqualTo(10));
@@ -39,7 +39,7 @@ namespace OpenNefia.Tests.Core.GameObjects
         {
             public override void Initialize()
             {
-                SubscribeLocalEvent<DummyComponent, TestStructEvent>(MyRefHandler);
+                SubscribeComponent<DummyComponent, TestStructEvent>(MyRefHandler);
             }
 
             private void MyRefHandler(EntityUid uid, DummyComponent component, ref TestStructEvent args)
@@ -73,8 +73,8 @@ namespace OpenNefia.Tests.Core.GameObjects
             public override void Initialize()
             {
                 // The below is not allowed, as you're subscribing by-ref and by-value to the same event...
-                SubscribeLocalEvent<DummyComponent, TestStructEvent>(MyRefHandler);
-                SubscribeLocalEvent<DummyTwoComponent, TestStructEvent>(MyValueHandler);
+                SubscribeComponent<DummyComponent, TestStructEvent>(MyRefHandler);
+                SubscribeComponent<DummyTwoComponent, TestStructEvent>(MyValueHandler);
             }
 
             private void MyValueHandler(EntityUid uid, DummyTwoComponent component, TestStructEvent args) { }
@@ -114,7 +114,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             // Act.
             var testEvent = new TestStructEvent {TestNumber = 5};
             var eventBus = simulation.Resolve<IEntityManager>().EventBus;
-            eventBus.RaiseLocalEvent(entity, ref testEvent);
+            eventBus.RaiseEvent(entity, ref testEvent);
 
             // Check that the entity systems changed the value correctly
             Assert.That(testEvent.TestNumber, Is.EqualTo(20));
@@ -127,7 +127,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             {
                 base.Initialize();
 
-                SubscribeLocalEvent<OrderComponentA, TestStructEvent>(OnA);
+                SubscribeComponent<OrderComponentA, TestStructEvent>(OnA);
             }
 
             private void OnA(EntityUid uid, OrderComponentA component, ref TestStructEvent args)
@@ -145,7 +145,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             {
                 base.Initialize();
 
-                SubscribeLocalEvent<OrderComponentB, TestStructEvent>(OnB, EventPriorities.Low);
+                SubscribeComponent<OrderComponentB, TestStructEvent>(OnB, EventPriorities.Low);
             }
 
             private void OnB(EntityUid uid, OrderComponentB component, ref TestStructEvent args)
@@ -163,8 +163,8 @@ namespace OpenNefia.Tests.Core.GameObjects
             {
                 base.Initialize();
 
-                SubscribeLocalEvent<OrderComponentC, TestStructEvent>(OnC, EventPriorities.Highest);
-                SubscribeLocalEvent<OrderComponentC2, TestStructEvent>(OnC2, EventPriorities.High);
+                SubscribeComponent<OrderComponentC, TestStructEvent>(OnC, EventPriorities.Highest);
+                SubscribeComponent<OrderComponentC2, TestStructEvent>(OnC2, EventPriorities.High);
             }
 
             private void OnC(EntityUid uid, OrderComponentC component, ref TestStructEvent args)

--- a/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.SystemEvent.cs
+++ b/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.SystemEvent.cs
@@ -27,7 +27,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             var subscriber = new TestEventSubscriber();
 
             // Act
-            void Code() => bus.SubscribeEvent(subscriber, (EntityEventHandler<TestEventArgs>)null!);
+            void Code() => bus.SubscribeBroadcastEvent(subscriber, (BroadcastEventHandler<TestEventArgs>)null!);
 
             //Assert
             Assert.Throws<ArgumentNullException>(Code);
@@ -43,7 +43,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             var bus = BusFactory();
 
             // Act
-            void Code() => bus.SubscribeEvent<TestEventArgs>(null!, ev => { });
+            void Code() => bus.SubscribeBroadcastEvent<TestEventArgs>(null!, ev => { });
 
             //Assert: this should do nothing
             Assert.Throws<ArgumentNullException>(Code);
@@ -64,8 +64,8 @@ namespace OpenNefia.Tests.Core.GameObjects
             void Handler(TestEventArgs ev) => delegateCallCount++;
 
             // 2 subscriptions 1 handler
-            bus.SubscribeEvent<TestEventArgs>(subscriber, Handler);
-            bus.SubscribeEvent<TestEventArgs>(subscriber, Handler);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(subscriber, Handler);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(subscriber, Handler);
 
             // Act
             bus.RaiseEvent(new TestEventArgs());
@@ -88,8 +88,8 @@ namespace OpenNefia.Tests.Core.GameObjects
             int delFooCount = 0;
             int delBarCount = 0;
 
-            bus.SubscribeEvent<TestEventArgs>(subscriber, ev => delFooCount++);
-            bus.SubscribeEvent<TestEventArgs>(subscriber, ev => delBarCount++);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(subscriber, ev => delFooCount++);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(subscriber, ev => delBarCount++);
 
             // Act
             bus.RaiseEvent(new TestEventArgs());
@@ -112,8 +112,8 @@ namespace OpenNefia.Tests.Core.GameObjects
             int delFooCount = 0;
             int delBarCount = 0;
 
-            bus.SubscribeEvent<TestEventArgs>(subscriber, ev => delFooCount++);
-            bus.SubscribeEvent<TestEventTwoArgs>(subscriber, ev => delBarCount++);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(subscriber, ev => delFooCount++);
+            bus.SubscribeBroadcastEvent<TestEventTwoArgs>(subscriber, ev => delBarCount++);
 
             // Act & Assert
             bus.RaiseEvent(new TestEventArgs());
@@ -139,7 +139,7 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             void Handler(TestEventArgs ev) { }
 
-            bus.SubscribeEvent<TestEventArgs>(subscriber, Handler);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(subscriber, Handler);
             bus.UnsubscribeEvent<TestEventArgs>(subscriber);
 
             // Act
@@ -191,7 +191,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             var subscriber = new TestEventSubscriber();
 
             int delCalledCount = 0;
-            bus.SubscribeEvent<TestEventTwoArgs>(subscriber, ev => delCalledCount++);
+            bus.SubscribeBroadcastEvent<TestEventTwoArgs>(subscriber, ev => delCalledCount++);
 
             // Act
             bus.RaiseEvent(new TestEventArgs());
@@ -213,7 +213,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             int delCallCount = 0;
             void Handler(TestEventArgs ev) => delCallCount++;
 
-            bus.SubscribeEvent<TestEventArgs>(subscriber, Handler);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(subscriber, Handler);
             bus.UnsubscribeEvent<TestEventArgs>(subscriber);
 
             // Act
@@ -268,7 +268,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             int delCallCount = 0;
             void Handler(TestEventArgs ev) => delCallCount++;
 
-            bus.SubscribeEvent<TestEventArgs>(subscriber, Handler);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(subscriber, Handler);
             bus.UnsubscribeEvents(subscriber);
 
             // Act
@@ -305,9 +305,9 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             void HandlerC(TestEventArgs ev) => c = true;
 
-            bus.SubscribeEvent<TestEventArgs>(new SubA(), HandlerA, EventPriorities.High);
-            bus.SubscribeEvent<TestEventArgs>(new SubB(), HandlerB, EventPriorities.Low);
-            bus.SubscribeEvent<TestEventArgs>(new SubC(), HandlerC);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(new SubA(), HandlerA, EventPriorities.High);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(new SubB(), HandlerB, EventPriorities.Low);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(new SubC(), HandlerC);
 
             // Act
             bus.RaiseEvent(new TestEventArgs());
@@ -345,9 +345,9 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             void HandlerC(TestEventArgs ev) => c = true;
 
-            bus.SubscribeEvent<TestEventArgs>(new SubA(), HandlerA, EventPriorities.High);
-            bus.SubscribeEvent<TestEventArgs>(new SubB(), HandlerB, EventPriorities.VeryLow);
-            bus.SubscribeEvent<TestEventArgs>(new SubC(), HandlerC, EventPriorities.Low);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(new SubA(), HandlerA, EventPriorities.High);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(new SubB(), HandlerB, EventPriorities.VeryLow);
+            bus.SubscribeBroadcastEvent<TestEventArgs>(new SubC(), HandlerC, EventPriorities.Low);
 
             // Act
             bus.RaiseEvent(new TestEventArgs());

--- a/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.SystemEvent.cs
+++ b/OpenNefia.Tests/Core/GameObjects/EntityEventBusTests.SystemEvent.cs
@@ -27,7 +27,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             var subscriber = new TestEventSubscriber();
 
             // Act
-            void Code() => bus.SubscribeEvent(EventSource.Local, subscriber, (EntityEventHandler<TestEventArgs>) null!);
+            void Code() => bus.SubscribeEvent(subscriber, (EntityEventHandler<TestEventArgs>)null!);
 
             //Assert
             Assert.Throws<ArgumentNullException>(Code);
@@ -43,7 +43,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             var bus = BusFactory();
 
             // Act
-            void Code() => bus.SubscribeEvent<TestEventArgs>(EventSource.Local, null!, ev => {});
+            void Code() => bus.SubscribeEvent<TestEventArgs>(null!, ev => { });
 
             //Assert: this should do nothing
             Assert.Throws<ArgumentNullException>(Code);
@@ -64,11 +64,11 @@ namespace OpenNefia.Tests.Core.GameObjects
             void Handler(TestEventArgs ev) => delegateCallCount++;
 
             // 2 subscriptions 1 handler
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
+            bus.SubscribeEvent<TestEventArgs>(subscriber, Handler);
+            bus.SubscribeEvent<TestEventArgs>(subscriber, Handler);
 
             // Act
-            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             //Assert
             Assert.That(delegateCallCount, Is.EqualTo(1));
@@ -88,11 +88,11 @@ namespace OpenNefia.Tests.Core.GameObjects
             int delFooCount = 0;
             int delBarCount = 0;
 
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, ev => delFooCount++);
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, ev => delBarCount++);
+            bus.SubscribeEvent<TestEventArgs>(subscriber, ev => delFooCount++);
+            bus.SubscribeEvent<TestEventArgs>(subscriber, ev => delBarCount++);
 
             // Act
-            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             // Assert
             Assert.That(delFooCount, Is.EqualTo(1));
@@ -112,39 +112,19 @@ namespace OpenNefia.Tests.Core.GameObjects
             int delFooCount = 0;
             int delBarCount = 0;
 
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, ev => delFooCount++);
-            bus.SubscribeEvent<TestEventTwoArgs>(EventSource.Local, subscriber, ev => delBarCount++);
+            bus.SubscribeEvent<TestEventArgs>(subscriber, ev => delFooCount++);
+            bus.SubscribeEvent<TestEventTwoArgs>(subscriber, ev => delBarCount++);
 
             // Act & Assert
-            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
             Assert.That(delFooCount, Is.EqualTo(1));
             Assert.That(delBarCount, Is.EqualTo(0));
 
             delFooCount = delBarCount = 0;
 
-            bus.RaiseEvent(EventSource.Local, new TestEventTwoArgs());
+            bus.RaiseEvent(new TestEventTwoArgs());
             Assert.That(delFooCount, Is.EqualTo(0));
             Assert.That(delBarCount, Is.EqualTo(1));
-        }
-
-        /// <summary>
-        /// Trying to subscribe with <see cref="EventSource.None"/> makes no sense and causes
-        /// a <see cref="ArgumentOutOfRangeException"/> to be thrown.
-        /// </summary>
-        [Test]
-        public void SubscribeEvent_SourceNone_ArgOutOfRange()
-        {
-            // Arrange
-            var bus = BusFactory();
-            var subscriber = new TestEventSubscriber();
-
-            void TestEventHandler(TestEventArgs args) { }
-
-            // Act
-            void Code() => bus.SubscribeEvent(EventSource.None, subscriber, (EntityEventHandler<TestEventArgs>)TestEventHandler);
-
-            //Assert
-            Assert.Throws<ArgumentOutOfRangeException>(Code);
         }
 
         /// <summary>
@@ -159,11 +139,11 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             void Handler(TestEventArgs ev) { }
 
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
-            bus.UnsubscribeEvent<TestEventArgs>(EventSource.Local, subscriber);
+            bus.SubscribeEvent<TestEventArgs>(subscriber, Handler);
+            bus.UnsubscribeEvent<TestEventArgs>(subscriber);
 
             // Act
-            bus.UnsubscribeEvent<TestEventArgs>(EventSource.Local, subscriber);
+            bus.UnsubscribeEvent<TestEventArgs>(subscriber);
 
             // Assert: Does not throw
         }
@@ -179,7 +159,7 @@ namespace OpenNefia.Tests.Core.GameObjects
             var subscriber = new TestEventSubscriber();
 
             // Act
-            bus.UnsubscribeEvent<TestEventArgs>(EventSource.Local, subscriber);
+            bus.UnsubscribeEvent<TestEventArgs>(subscriber);
 
             // Assert: Does not throw
         }
@@ -194,28 +174,10 @@ namespace OpenNefia.Tests.Core.GameObjects
             var bus = BusFactory();
 
             // Act
-            void Code() => bus.UnsubscribeEvent<TestEventArgs>(EventSource.Local, null!);
+            void Code() => bus.UnsubscribeEvent<TestEventArgs>(null!);
 
             // Assert
             Assert.Throws<ArgumentNullException>(Code);
-        }
-
-        /// <summary>
-        /// An event cannot be subscribed to with <see cref="EventSource.None"/>, so trying to unsubscribe
-        /// with an <see cref="EventSource.None"/> causes a <see cref="ArgumentOutOfRangeException"/> to be thrown.
-        /// </summary>
-        [Test]
-        public void UnsubscribeEvent_SourceNone_ArgOutOfRange()
-        {
-            // Arrange
-            var bus = BusFactory();
-            var subscriber = new TestEventSubscriber();
-
-            // Act
-            void Code() => bus.UnsubscribeEvent<TestEventArgs>(EventSource.None, subscriber);
-
-            // Assert
-            Assert.Throws<ArgumentOutOfRangeException>(Code);
         }
 
         /// <summary>
@@ -229,10 +191,10 @@ namespace OpenNefia.Tests.Core.GameObjects
             var subscriber = new TestEventSubscriber();
 
             int delCalledCount = 0;
-            bus.SubscribeEvent<TestEventTwoArgs>(EventSource.Local, subscriber, ev => delCalledCount++);
+            bus.SubscribeEvent<TestEventTwoArgs>(subscriber, ev => delCalledCount++);
 
             // Act
-            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             // Assert
             Assert.That(delCalledCount, Is.EqualTo(0));
@@ -251,31 +213,14 @@ namespace OpenNefia.Tests.Core.GameObjects
             int delCallCount = 0;
             void Handler(TestEventArgs ev) => delCallCount++;
 
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
-            bus.UnsubscribeEvent<TestEventArgs>(EventSource.Local, subscriber);
+            bus.SubscribeEvent<TestEventArgs>(subscriber, Handler);
+            bus.UnsubscribeEvent<TestEventArgs>(subscriber);
 
             // Act
-            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             // Assert
             Assert.That(delCallCount, Is.EqualTo(0));
-        }
-
-        /// <summary>
-        /// Trying to raise an event with <see cref="EventSource.None"/> makes no sense and causes
-        /// a <see cref="ArgumentOutOfRangeException"/> to be thrown.
-        /// </summary>
-        [Test]
-        public void RaiseEvent_SourceNone_ArgOutOfRange()
-        {
-            // Arrange
-            var bus = BusFactory();
-
-            // Act
-            void Code() => bus.RaiseEvent(EventSource.None, new TestEventArgs());
-
-            // Assert
-            Assert.Throws<ArgumentOutOfRangeException>(Code);
         }
 
         /// <summary>
@@ -323,11 +268,11 @@ namespace OpenNefia.Tests.Core.GameObjects
             int delCallCount = 0;
             void Handler(TestEventArgs ev) => delCallCount++;
 
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, subscriber, Handler);
+            bus.SubscribeEvent<TestEventArgs>(subscriber, Handler);
             bus.UnsubscribeEvents(subscriber);
 
             // Act
-            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             // Assert
             Assert.That(delCallCount, Is.EqualTo(0));
@@ -360,12 +305,12 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             void HandlerC(TestEventArgs ev) => c = true;
 
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, new SubA(), HandlerA, EventPriorities.High);
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, new SubB(), HandlerB, EventPriorities.Low);
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, new SubC(), HandlerC);
+            bus.SubscribeEvent<TestEventArgs>(new SubA(), HandlerA, EventPriorities.High);
+            bus.SubscribeEvent<TestEventArgs>(new SubB(), HandlerB, EventPriorities.Low);
+            bus.SubscribeEvent<TestEventArgs>(new SubC(), HandlerC);
 
             // Act
-            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             // Assert
             Assert.That(a, Is.True, "A did not fire");
@@ -400,12 +345,12 @@ namespace OpenNefia.Tests.Core.GameObjects
 
             void HandlerC(TestEventArgs ev) => c = true;
 
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, new SubA(), HandlerA, EventPriorities.High);
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, new SubB(), HandlerB, EventPriorities.VeryLow);
-            bus.SubscribeEvent<TestEventArgs>(EventSource.Local, new SubC(), HandlerC, EventPriorities.Low);
+            bus.SubscribeEvent<TestEventArgs>(new SubA(), HandlerA, EventPriorities.High);
+            bus.SubscribeEvent<TestEventArgs>(new SubB(), HandlerB, EventPriorities.VeryLow);
+            bus.SubscribeEvent<TestEventArgs>(new SubC(), HandlerC, EventPriorities.Low);
 
             // Act
-            bus.RaiseEvent(EventSource.Local, new TestEventArgs());
+            bus.RaiseEvent(new TestEventArgs());
 
             // Assert
             Assert.That(a, Is.True, "A did not fire");

--- a/OpenNefia.Tests/Core/GameObjects/Systems/SpatialSystem_Tests.cs
+++ b/OpenNefia.Tests/Core/GameObjects/Systems/SpatialSystem_Tests.cs
@@ -46,7 +46,7 @@ namespace OpenNefia.Tests.Core.GameObjects.Systems
             var subscriber = new Subscriber();
             int calledCount = 0;
             var entUid = new { Uid = EntityUid.Invalid };
-            entMan.EventBus.SubscribeEvent<EntityPositionChangedEvent>(EventSource.Local, subscriber, MoveEventHandler);
+            entMan.EventBus.SubscribeEvent<EntityPositionChangedEvent>(subscriber, MoveEventHandler);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(map.Id, Vector2i.Zero));
 
             Assert.That(calledCount, Is.EqualTo(1));
@@ -77,7 +77,7 @@ namespace OpenNefia.Tests.Core.GameObjects.Systems
             var ent = entMan.SpawnEntity(null, new MapCoordinates(map.Id, Vector2i.Zero));
             var spatial = entMan.GetComponent<SpatialComponent>(ent);
 
-            entMan.EventBus.SubscribeEvent<EntityPositionChangedEvent>(EventSource.Local, subscriber, MoveEventHandler);
+            entMan.EventBus.SubscribeEvent<EntityPositionChangedEvent>(subscriber, MoveEventHandler);
 
             spatial.WorldPosition = Vector2i.One;
 

--- a/OpenNefia.Tests/Core/GameObjects/Systems/SpatialSystem_Tests.cs
+++ b/OpenNefia.Tests/Core/GameObjects/Systems/SpatialSystem_Tests.cs
@@ -46,7 +46,7 @@ namespace OpenNefia.Tests.Core.GameObjects.Systems
             var subscriber = new Subscriber();
             int calledCount = 0;
             var entUid = new { Uid = EntityUid.Invalid };
-            entMan.EventBus.SubscribeEvent<EntityPositionChangedEvent>(subscriber, MoveEventHandler);
+            entMan.EventBus.SubscribeBroadcastEvent<EntityPositionChangedEvent>(subscriber, MoveEventHandler);
             var ent1 = entMan.SpawnEntity(null, new MapCoordinates(map.Id, Vector2i.Zero));
 
             Assert.That(calledCount, Is.EqualTo(1));
@@ -77,7 +77,7 @@ namespace OpenNefia.Tests.Core.GameObjects.Systems
             var ent = entMan.SpawnEntity(null, new MapCoordinates(map.Id, Vector2i.Zero));
             var spatial = entMan.GetComponent<SpatialComponent>(ent);
 
-            entMan.EventBus.SubscribeEvent<EntityPositionChangedEvent>(subscriber, MoveEventHandler);
+            entMan.EventBus.SubscribeBroadcastEvent<EntityPositionChangedEvent>(subscriber, MoveEventHandler);
 
             spatial.WorldPosition = Vector2i.One;
 


### PR DESCRIPTION
Adds these much-needed features to the event system:

1. Ability to add multiple event subscribers per component/event pair.
2. Ability to subscribe to events on all entities ignoring components. They're invoked as `(EntityUid, EventArgs)`.
3. Simplification of event subscription method names. They're now divided into three types:
   a. Component: Targets entities with a specific component.
   b. Entity: Targets all entities, regardless of components.
   c. Broadcast: Targets all entities, omits `EntityUid` in the handler.