### PR TITLE
Replace padding

### DIFF
--- a/OpenNefia.Content/CharaAppearance/CharaAppearanceControl.cs
+++ b/OpenNefia.Content/CharaAppearance/CharaAppearanceControl.cs
@@ -266,7 +266,7 @@ namespace OpenNefia.Content.CharaAppearance
             TextTopicCategory.SetPosition(Window.X + 34, Window.Y + 36);
             AppearanceList.SetPosition(Window.X + 30, Window.Y + 65);
             AssetAppearanceDeco.SetPosition(Window.X + Window.Width - 40, Window.Y);
-            PreviewPanel.SetPosition(Window.X + 230, Window.Y + 70);
+            PreviewPanel.SetPosition(Window.X + 240, Window.Y + 65);
         }
 
         public override void Draw()

--- a/OpenNefia.Content/CharaAppearance/CharaAppearanceList.cs
+++ b/OpenNefia.Content/CharaAppearance/CharaAppearanceList.cs
@@ -13,6 +13,7 @@ using static OpenNefia.Content.Prototypes.Protos;
 using OpenNefia.Core.Prototypes;
 using OpenNefia.Core.UI;
 using OpenNefia.Content.Portraits;
+using OpenNefia.Content.UI;
 
 namespace OpenNefia.Content.CharaAppearance
 {
@@ -39,6 +40,7 @@ namespace OpenNefia.Content.CharaAppearance
 
         public sealed class ChangePage : CharaAppearanceUICellData
         {
+            public override bool DrawArrows => false;
             public CharaAppearancePage Page { get; set; }
 
             public ChangePage(CharaAppearancePage page)
@@ -199,45 +201,37 @@ namespace OpenNefia.Content.CharaAppearance
     {
         [Child] private AssetDrawable AssetArrowLeft;
         [Child] private AssetDrawable AssetArrowRight;
-
-        private string _baseText;
+        [Child] private UiText TextValue;
 
         public CharaAppearanceUIListCell(CharaAppearanceUICellData data, string text)
             : base(data, new UiText(text))
         {
-            _baseText = text;
-
             AssetArrowLeft = new AssetDrawable(Asset.ArrowLeft);
             AssetArrowRight = new AssetDrawable(Asset.ArrowRight);
+            TextValue = new UiText(UiFonts.ListText);
 
             RebuildText();
         }
 
         public void RebuildText()
         {
-            var valueText = Data.Text;
-            var baseText = _baseText;
-
-            if (valueText != string.Empty)
-                baseText = baseText.WidePadRight(8, ' ').WideSubstring(0, 8);
-
-            UiText.Text = $"{baseText} {valueText}";
+            TextValue.Text = Data.Text;
         }
 
         public override void SetSize(float width, float height)
         {
             base.SetSize(width, height);
             AssetArrowLeft.SetPreferredSize();
-            UiText.SetSize(110, UiText.Height);
+            TextValue.SetPreferredSize();
             AssetArrowRight.SetPreferredSize();
         }
 
         public override void SetPosition(float x, float y)
         {
             base.SetPosition(x, y);
-            AssetArrowLeft.SetPosition(X, Y - 3);
-            UiText.SetPosition(AssetArrowLeft.Rect.Right + 5, Y + 2);
-            AssetArrowRight.SetPosition(UiText.Rect.Right + 5 + 1, Y - 3);
+            AssetArrowLeft.SetPosition(X + 115, Y - 5);
+            TextValue.SetPosition(AssetArrowLeft.Rect.Right + 5, Y);
+            AssetArrowRight.SetPosition(X + 173, Y - 5);
         }
 
         public void Change(int delta)
@@ -250,12 +244,14 @@ namespace OpenNefia.Content.CharaAppearance
         {
             UiText.Update(dt);
             AssetArrowLeft.Update(dt);
+            TextValue.Update(dt);
             AssetArrowRight.Update(dt);
         }
 
         public override void Draw()
         {
-            UiText.Draw();
+            base.Draw();
+            TextValue.Draw();
 
             if (Data.DrawArrows)
             {

--- a/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
+++ b/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
@@ -246,7 +246,7 @@ namespace OpenNefia.Content.CharaInfo
                     dict[_locScope.GetString("Group.Personal.Alias")] = alias.Alias;
                 dict[_locScope.GetString("Group.Personal.Race")] = Loc.GetPrototypeString(chara.Race, "Name");
                 dict[_locScope.GetString("Group.Personal.Sex")] = Loc.GetString($"Elona.Gender.Names.{chara.Gender}.Normal").FirstCharToUpper();
-                SetupContainer(NameContainer, 4, dict);
+                SetupContainer(NameContainer, 10, dict);
                 dict.Clear();
 
                 dict[string.Empty] = string.Empty;
@@ -257,7 +257,7 @@ namespace OpenNefia.Content.CharaInfo
                     dict[_locScope.GetString("Group.Personal.Height")] = $"{weight.Height} {_locScope.GetString("Group.Personal.Cm")}";
                     dict[_locScope.GetString("Group.Personal.Weight")] = $"{weight.Weight.Buffed} {_locScope.GetString("Group.Personal.Kg")}";
                 }
-                SetupContainer(ClassContainer, 4, dict);
+                SetupContainer(ClassContainer, 10, dict);
                 dict.Clear();
             }
 
@@ -281,7 +281,7 @@ namespace OpenNefia.Content.CharaInfo
             }
             dict[_locScope.GetString("Group.Exp.God")] = levelGodName;
             dict[_locScope.GetString("Group.Exp.Guild")] = levelGuildName;
-            SetupContainer(ExpContainer, 5, dict);
+            SetupContainer(ExpContainer, 10, dict);
             dict.Clear();
 
             //
@@ -291,8 +291,8 @@ namespace OpenNefia.Content.CharaInfo
             AttributeContainer.AddElement(new UiTextTopic(_locScope.GetString("Topic.Attribute")));
             if (skills != null)
             {
-                AttributeContainer.AddLayout(LayoutType.Spacer, 9);
-                AttributeContainer.AddLayout(LayoutType.XOffset, 10);
+                AttributeContainer.AddLayout(LayoutType.Spacer, 12);
+                AttributeContainer.AddLayout(LayoutType.XOffset, 1);
                 foreach (var attrProto in _skillsSys.EnumerateBaseAttributes())
                 {
                     var cont = new UiHorizontalContainer();
@@ -310,9 +310,9 @@ namespace OpenNefia.Content.CharaInfo
                         + CharaSheetHelpers.GetPotentialDescription(attrLvl.Potential);
 
                     cont.AddElement(new AttributeIcon(attrId));
-                    cont.AddLayout(LayoutType.Spacer, 14);
-                    cont.AddLayout(LayoutType.YOffset, -6);
-                    cont.AddElement(MakeInfoContainer(Loc.GetPrototypeString(attrId, "ShortName"), 5, content));
+                    cont.AddLayout(LayoutType.Spacer, 5);
+                    cont.AddLayout(LayoutType.YOffset, -9);
+                    cont.AddElement(MakeInfoContainer(Loc.GetPrototypeString(attrId, "ShortName"), 35, content));
 
                     AttributeContainer.AddElement(cont);
                 }
@@ -331,7 +331,7 @@ namespace OpenNefia.Content.CharaInfo
                 dict[string.Empty] = string.Empty;
                 dict[_locScope.GetString("Group.Attribute.Fame")] = attributeFame.ToString();
                 dict[_locScope.GetString("Group.Attribute.Karma")] = attributeKarma.ToString();
-                SetupContainer(SpecialStatContainer, 6, dict);
+                SetupContainer(SpecialStatContainer, 10, dict);
                 dict.Clear();
             }
 
@@ -351,15 +351,15 @@ namespace OpenNefia.Content.CharaInfo
             var traceDays = _world.State.GameDate.Day - _world.State.InitialDate.Day;
 
             TraceContainer.AddElement(new UiTextTopic(_locScope.GetString("Topic.Trace")));
-            TraceContainer.AddLayout(LayoutType.Spacer, 6);
+            TraceContainer.AddLayout(LayoutType.Spacer, 5);
             TraceContainer.AddLayout(LayoutType.XOffset, 3);
             dict[_locScope.GetString("Group.Trace.Turns")] = $"{_locScope.GetString("Group.Trace.TurnsCounter", ("turns", _world.State.PlayTurns))}";
             dict[_locScope.GetString("Group.Trace.Days")] = $"{_locScope.GetString("Group.Trace.DaysCounter", ("days", traceDays))}";
             dict[_locScope.GetString("Group.Trace.Kills")] = _world.State.TotalKills.ToString();
             dict[_locScope.GetString("Group.Trace.Time")] = string.Empty;
-            SetupContainer(TraceContainer, 4, dict);
+            SetupContainer(TraceContainer, 10, dict);
             PlayTimeContainer = (UiContainer)TraceContainer.Entries[6].Element!;
-            TextPlayTime = (UiText)PlayTimeContainer.Entries[2].Element!;
+            TextPlayTime = (UiText)PlayTimeContainer.Entries[3].Element!;
             dict.Clear();
 
             //
@@ -367,7 +367,7 @@ namespace OpenNefia.Content.CharaInfo
             //
 
             ExtraContainer.AddElement(new UiTextTopic(_locScope.GetString("Topic.Extra")));
-            ExtraContainer.AddLayout(LayoutType.Spacer, 6);
+            ExtraContainer.AddLayout(LayoutType.Spacer, 5);
             ExtraContainer.AddLayout(LayoutType.XOffset, 3);
 
             if (cargoHold != null)
@@ -379,7 +379,7 @@ namespace OpenNefia.Content.CharaInfo
             var eqWeight = _equip.GetTotalEquipmentWeight(_charaEntity);
             dict[_locScope.GetString("Group.Extra.EquipWeight")] = $"{UiUtils.DisplayWeight(eqWeight)} {EquipmentHelpers.DisplayArmorClass(eqWeight)}";
             dict[_locScope.GetString("Group.Extra.DeepestLevel")] = $"{_world.State.DeepestLevel}{_locScope.GetString("Group.Extra.DeepestLevelCounter", ("level", _world.State.DeepestLevel))}";
-            SetupContainer(ExtraContainer, 6, dict);
+            SetupContainer(ExtraContainer, 10, dict);
             dict.Clear();
 
             //
@@ -401,7 +401,7 @@ namespace OpenNefia.Content.CharaInfo
 
         private void SetupContainer(UiContainer cont, int xOffset, IDictionary<string, string> content)
         {
-            var maxLen = content.Select(x => x.Key).Max(x => x.Length);
+            var maxLen = (int)Math.Round(content.Select(x => x.Key).Max(x => UiFonts.CharaSheetInfo.LoveFont.GetWidthV(UIScale, x)));
             foreach (var item in content)
             {
                 cont.AddElement(MakeInfoContainer(item.Key, maxLen + xOffset, item.Value));
@@ -411,8 +411,9 @@ namespace OpenNefia.Content.CharaInfo
         private UiContainer MakeInfoContainer(string name, int xOffset, string content)
         {
             var cont = new UiHorizontalContainer();
-            cont.AddElement(new UiText(UiFonts.CharaSheetInfo, name.WidePadRight(xOffset)));
+            cont.AddElement(new UiText(UiFonts.CharaSheetInfo, name));
             cont.AddLayout(LayoutType.YOffset, -1);
+            cont.AddLayout(LayoutType.XMin, xOffset);
             cont.AddElement(new UiText(UiFonts.CharaSheetInfoContent, content));
             return cont;
         }
@@ -436,11 +437,11 @@ namespace OpenNefia.Content.CharaInfo
             base.SetPosition(x, y);
             FaceFrame.SetPosition(x + 558, y + 23);
 
-            NameContainer.SetPosition(x + 30, y + 47);
+            NameContainer.SetPosition(x + 30, y + 42);
             NameContainer.Relayout();
-            ClassContainer.SetPosition(x + 215, NameContainer.Y);
+            ClassContainer.SetPosition(x + 240, NameContainer.Y);
             ClassContainer.Relayout();
-            ExpContainer.SetPosition(x + 355, NameContainer.Y);
+            ExpContainer.SetPosition(x + 370, NameContainer.Y);
             ExpContainer.Relayout();
             AttributeContainer.SetPosition(x + 27, y + 125);
             AttributeContainer.Relayout();

--- a/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
+++ b/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
@@ -72,7 +72,7 @@ namespace OpenNefia.Content.CharaInfo
         private const int SheetWidth = 700;
         private const int SheetHeight = 400;
         private const int ContainerSpacing = 4;
-        private const int AttributeContainerSpacing = 6;
+        private const int AttributeIconContainerSpacing = 7;
         private const int AttributeSpacing = 5;
         private const int AttributePotentialSpacing = 8;
 
@@ -84,6 +84,7 @@ namespace OpenNefia.Content.CharaInfo
         [Child] private UiContainer ClassContainer;
         [Child] private UiContainer ExpContainer;
         [Child] private UiContainer AttributeContainer;
+        [Child] private UiContainer AttributeIconContainer;
         [Child] private UiContainer SpecialStatContainer;
         [Child] private UiContainer BlessingContainer;
         [Child] private UiContainer TraceContainer;
@@ -115,7 +116,8 @@ namespace OpenNefia.Content.CharaInfo
             NameContainer = new UiVerticalContainer { YSpace = ContainerSpacing };
             ClassContainer = new UiVerticalContainer { YSpace = ContainerSpacing };
             ExpContainer = new UiVerticalContainer { YSpace = ContainerSpacing };
-            AttributeContainer = new UiVerticalContainer { YSpace = AttributeContainerSpacing };
+            AttributeContainer = new UiVerticalContainer { YSpace = ContainerSpacing };
+            AttributeIconContainer = new UiVerticalContainer { YSpace = AttributeIconContainerSpacing };
             SpecialStatContainer = new UiVerticalContainer { YSpace = ContainerSpacing };
             BlessingContainer = new UiVerticalContainer();
             TraceContainer = new UiVerticalContainer { YSpace = ContainerSpacing };
@@ -173,6 +175,7 @@ namespace OpenNefia.Content.CharaInfo
             ClassContainer.Clear();
             ExpContainer.Clear();
             AttributeContainer.Clear();
+            AttributeIconContainer.Clear();
             SpecialStatContainer.Clear();
             BlessingContainer.Clear();
             TraceContainer.Clear();
@@ -291,11 +294,10 @@ namespace OpenNefia.Content.CharaInfo
             AttributeContainer.AddElement(new UiTextTopic(_locScope.GetString("Topic.Attribute")));
             if (skills != null)
             {
-                AttributeContainer.AddLayout(LayoutType.Spacer, 12);
-                AttributeContainer.AddLayout(LayoutType.XOffset, 1);
+                AttributeContainer.AddLayout(LayoutType.Spacer, 2);
+                AttributeContainer.AddLayout(LayoutType.XOffset, 3);
                 foreach (var attrProto in _skillsSys.EnumerateBaseAttributes())
                 {
-                    var cont = new UiHorizontalContainer();
                     var attrId = attrProto.GetStrongID();
 
                     if (!skills.Skills.TryGetValue(attrId, out var attrLvl))
@@ -303,18 +305,17 @@ namespace OpenNefia.Content.CharaInfo
 
                     string currentAmt = attrLvl.Level.Buffed.ToString();
                     string orgAmt = $"({attrLvl.Level.Base})";
-                    var content = currentAmt
-                        + new string(' ', Math.Max(1, AttributeSpacing - currentAmt.Length))
-                        + orgAmt
-                        + new string(' ', Math.Max(1, AttributePotentialSpacing - orgAmt.Length))
-                        + CharaSheetHelpers.GetPotentialDescription(attrLvl.Potential);
+                    string potential = CharaSheetHelpers.GetPotentialDescription(attrLvl.Potential);
 
-                    cont.AddElement(new AttributeIcon(attrId));
-                    cont.AddLayout(LayoutType.Spacer, 5);
-                    cont.AddLayout(LayoutType.YOffset, -9);
-                    cont.AddElement(MakeInfoContainer(Loc.GetPrototypeString(attrId, "ShortName"), 35, content));
+                    var content = MakeInfoContainer(Loc.GetPrototypeString(attrId, "ShortName"), 35, currentAmt);
+                    content.AddLayout(LayoutType.YOffset, -1);
+                    content.AddLayout(LayoutType.XMin, 75);
+                    content.AddElement(new UiText(UiFonts.CharaSheetInfoContent, orgAmt));
+                    content.AddLayout(LayoutType.XMin, 125);
+                    content.AddElement(new UiText(UiFonts.CharaSheetInfoContent, potential));
 
-                    AttributeContainer.AddElement(cont);
+                    AttributeContainer.AddElement(content);
+                    AttributeIconContainer.AddElement(new AttributeIcon(attrId));
                 }
 
                 var attributeInsanity = sanity != null ? sanity.Insanity : 0;
@@ -351,7 +352,7 @@ namespace OpenNefia.Content.CharaInfo
             var traceDays = _world.State.GameDate.Day - _world.State.InitialDate.Day;
 
             TraceContainer.AddElement(new UiTextTopic(_locScope.GetString("Topic.Trace")));
-            TraceContainer.AddLayout(LayoutType.Spacer, 5);
+            TraceContainer.AddLayout(LayoutType.Spacer, 2);
             TraceContainer.AddLayout(LayoutType.XOffset, 3);
             dict[_locScope.GetString("Group.Trace.Turns")] = $"{_locScope.GetString("Group.Trace.TurnsCounter", ("turns", _world.State.PlayTurns))}";
             dict[_locScope.GetString("Group.Trace.Days")] = $"{_locScope.GetString("Group.Trace.DaysCounter", ("days", traceDays))}";
@@ -367,7 +368,7 @@ namespace OpenNefia.Content.CharaInfo
             //
 
             ExtraContainer.AddElement(new UiTextTopic(_locScope.GetString("Topic.Extra")));
-            ExtraContainer.AddLayout(LayoutType.Spacer, 5);
+            ExtraContainer.AddLayout(LayoutType.Spacer, 2);
             ExtraContainer.AddLayout(LayoutType.XOffset, 3);
 
             if (cargoHold != null)
@@ -392,6 +393,7 @@ namespace OpenNefia.Content.CharaInfo
             ClassContainer.Relayout();
             ExpContainer.Relayout();
             AttributeContainer.Relayout();
+            AttributeIconContainer.Relayout();
             SpecialStatContainer.Relayout();
             BlessingContainer.Relayout();
             TraceContainer.Relayout();
@@ -443,15 +445,17 @@ namespace OpenNefia.Content.CharaInfo
             ClassContainer.Relayout();
             ExpContainer.SetPosition(x + 370, NameContainer.Y);
             ExpContainer.Relayout();
-            AttributeContainer.SetPosition(x + 27, y + 125);
+            AttributeContainer.SetPosition(NameContainer.X - 3, y + 125);
             AttributeContainer.Relayout();
-            SpecialStatContainer.SetPosition(x + 240, y + 155);
+            AttributeIconContainer.SetPosition(X + 20, Y + 160);
+            AttributeIconContainer.Relayout();
+            SpecialStatContainer.SetPosition(ClassContainer.X, y + 151);
             SpecialStatContainer.Relayout();
             BlessingContainer.SetPosition(X + 400, AttributeContainer.Y);
             BlessingContainer.Relayout();
             TraceContainer.SetPosition(AttributeContainer.X, y + 285);
             TraceContainer.Relayout();
-            ExtraContainer.SetPosition(X + 215, TraceContainer.Y);
+            ExtraContainer.SetPosition(ClassContainer.X - 3, TraceContainer.Y);
             ExtraContainer.Relayout();
             RollsContainer.SetPosition(BlessingContainer.X, y + 260);
             RollsContainer.Relayout();
@@ -469,6 +473,7 @@ namespace OpenNefia.Content.CharaInfo
             ClassContainer.Update(dt);
             ExpContainer.Update(dt);
             AttributeContainer.Update(dt);
+            AttributeIconContainer.Update(dt);
             SpecialStatContainer.Update(dt);
             BlessingContainer.Update(dt);
             TraceContainer.Update(dt);
@@ -490,6 +495,7 @@ namespace OpenNefia.Content.CharaInfo
             ClassContainer.Draw();
             ExpContainer.Draw();
             AttributeContainer.Draw();
+            AttributeIconContainer.Draw();
             SpecialStatContainer.Draw();
             BlessingContainer.Draw();
             TraceContainer.Draw();

--- a/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
+++ b/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
@@ -308,9 +308,9 @@ namespace OpenNefia.Content.CharaInfo
 
                     var content = MakeInfoContainer(Loc.GetPrototypeString(attrId, "ShortName"), 35, currentAmt);
                     content.AddLayout(LayoutType.YOffset, -1);
-                    content.AddLayout(LayoutType.XMin, 75);
+                    content.AddLayout(LayoutType.XMin, 70);
                     content.AddElement(new UiText(UiFonts.CharaSheetInfoContent, orgAmt));
-                    content.AddLayout(LayoutType.XMin, 125);
+                    content.AddLayout(LayoutType.XMin, 115);
                     content.AddElement(new UiText(UiFonts.CharaSheetInfoContent, potential));
 
                     AttributeContainer.AddElement(content);
@@ -440,9 +440,9 @@ namespace OpenNefia.Content.CharaInfo
 
             NameContainer.SetPosition(x + 30, y + 42);
             NameContainer.Relayout();
-            ClassContainer.SetPosition(x + 240, NameContainer.Y);
+            ClassContainer.SetPosition(x + 230, NameContainer.Y);
             ClassContainer.Relayout();
-            ExpContainer.SetPosition(x + 370, NameContainer.Y);
+            ExpContainer.SetPosition(x + 360, NameContainer.Y);
             ExpContainer.Relayout();
             AttributeContainer.SetPosition(NameContainer.X - TopicToEntryXOffset, y + 125);
             AttributeContainer.Relayout();

--- a/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
+++ b/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
@@ -294,7 +294,7 @@ namespace OpenNefia.Content.CharaInfo
             if (skills != null)
             {
                 AttributeContainer.AddLayout(LayoutType.Spacer, 2);
-                AttributeContainer.AddLayout(LayoutType.XOffset, TopicToEntryXOffset);
+                AttributeContainer.AddLayout(LayoutType.XOffset, TopicToEntryXOffset + 18);
                 foreach (var attrProto in _skillsSys.EnumerateBaseAttributes())
                 {
                     var attrId = attrProto.GetStrongID();
@@ -308,9 +308,9 @@ namespace OpenNefia.Content.CharaInfo
 
                     var content = MakeInfoContainer(Loc.GetPrototypeString(attrId, "ShortName"), 35, currentAmt);
                     content.AddLayout(LayoutType.YOffset, -1);
-                    content.AddLayout(LayoutType.XMin, 70);
+                    content.AddLayout(LayoutType.XMin, 67);
                     content.AddElement(new UiText(UiFonts.CharaSheetInfoContent, orgAmt));
-                    content.AddLayout(LayoutType.XMin, 115);
+                    content.AddLayout(LayoutType.XMin, 110);
                     content.AddElement(new UiText(UiFonts.CharaSheetInfoContent, potential));
 
                     AttributeContainer.AddElement(content);
@@ -440,13 +440,13 @@ namespace OpenNefia.Content.CharaInfo
 
             NameContainer.SetPosition(x + 30, y + 42);
             NameContainer.Relayout();
-            ClassContainer.SetPosition(x + 225, NameContainer.Y);
+            ClassContainer.SetPosition(x + 230, NameContainer.Y);
             ClassContainer.Relayout();
             ExpContainer.SetPosition(x + 360, NameContainer.Y);
             ExpContainer.Relayout();
             AttributeContainer.SetPosition(NameContainer.X - TopicToEntryXOffset, y + 122);
             AttributeContainer.Relayout();
-            AttributeIconContainer.SetPosition(X + 20, Y + 157);
+            AttributeIconContainer.SetPosition(X + 38, Y + 157);
             AttributeIconContainer.Relayout();
             SpecialStatContainer.SetPosition(ClassContainer.X, y + 148);
             SpecialStatContainer.Relayout();

--- a/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
+++ b/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
@@ -73,8 +73,7 @@ namespace OpenNefia.Content.CharaInfo
         private const int SheetHeight = 400;
         private const int ContainerSpacing = 4;
         private const int AttributeIconContainerSpacing = 7;
-        private const int AttributeSpacing = 5;
-        private const int AttributePotentialSpacing = 8;
+        private const int TopicToEntryXOffset = 3;
 
         private IAssetInstance AssetIeSheet;
 
@@ -295,7 +294,7 @@ namespace OpenNefia.Content.CharaInfo
             if (skills != null)
             {
                 AttributeContainer.AddLayout(LayoutType.Spacer, 2);
-                AttributeContainer.AddLayout(LayoutType.XOffset, 3);
+                AttributeContainer.AddLayout(LayoutType.XOffset, TopicToEntryXOffset);
                 foreach (var attrProto in _skillsSys.EnumerateBaseAttributes())
                 {
                     var attrId = attrProto.GetStrongID();
@@ -353,7 +352,7 @@ namespace OpenNefia.Content.CharaInfo
 
             TraceContainer.AddElement(new UiTextTopic(_locScope.GetString("Topic.Trace")));
             TraceContainer.AddLayout(LayoutType.Spacer, 2);
-            TraceContainer.AddLayout(LayoutType.XOffset, 3);
+            TraceContainer.AddLayout(LayoutType.XOffset, TopicToEntryXOffset);
             dict[_locScope.GetString("Group.Trace.Turns")] = $"{_locScope.GetString("Group.Trace.TurnsCounter", ("turns", _world.State.PlayTurns))}";
             dict[_locScope.GetString("Group.Trace.Days")] = $"{_locScope.GetString("Group.Trace.DaysCounter", ("days", traceDays))}";
             dict[_locScope.GetString("Group.Trace.Kills")] = _world.State.TotalKills.ToString();
@@ -369,7 +368,7 @@ namespace OpenNefia.Content.CharaInfo
 
             ExtraContainer.AddElement(new UiTextTopic(_locScope.GetString("Topic.Extra")));
             ExtraContainer.AddLayout(LayoutType.Spacer, 2);
-            ExtraContainer.AddLayout(LayoutType.XOffset, 3);
+            ExtraContainer.AddLayout(LayoutType.XOffset, TopicToEntryXOffset);
 
             if (cargoHold != null)
             {
@@ -445,7 +444,7 @@ namespace OpenNefia.Content.CharaInfo
             ClassContainer.Relayout();
             ExpContainer.SetPosition(x + 370, NameContainer.Y);
             ExpContainer.Relayout();
-            AttributeContainer.SetPosition(NameContainer.X - 3, y + 125);
+            AttributeContainer.SetPosition(NameContainer.X - TopicToEntryXOffset, y + 125);
             AttributeContainer.Relayout();
             AttributeIconContainer.SetPosition(X + 20, Y + 160);
             AttributeIconContainer.Relayout();
@@ -455,12 +454,12 @@ namespace OpenNefia.Content.CharaInfo
             BlessingContainer.Relayout();
             TraceContainer.SetPosition(AttributeContainer.X, y + 285);
             TraceContainer.Relayout();
-            ExtraContainer.SetPosition(ClassContainer.X - 3, TraceContainer.Y);
+            ExtraContainer.SetPosition(ClassContainer.X - TopicToEntryXOffset, TraceContainer.Y);
             ExtraContainer.Relayout();
             RollsContainer.SetPosition(BlessingContainer.X, y + 260);
             RollsContainer.Relayout();
-            TextBuffHintTopic.SetPosition(x + 70, y + 369 + 8);
-            TextBuffHintBody.SetPosition(x + 108, y + 366 + 8);
+            TextBuffHintTopic.SetPosition(x + 30, y + 379);
+            TextBuffHintBody.SetPosition(x + 65, y + 379);
         }
 
         public override void Update(float dt)

--- a/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
+++ b/OpenNefia.Content/CharaInfo/CharaSheetControl.cs
@@ -440,26 +440,26 @@ namespace OpenNefia.Content.CharaInfo
 
             NameContainer.SetPosition(x + 30, y + 42);
             NameContainer.Relayout();
-            ClassContainer.SetPosition(x + 230, NameContainer.Y);
+            ClassContainer.SetPosition(x + 225, NameContainer.Y);
             ClassContainer.Relayout();
             ExpContainer.SetPosition(x + 360, NameContainer.Y);
             ExpContainer.Relayout();
-            AttributeContainer.SetPosition(NameContainer.X - TopicToEntryXOffset, y + 125);
+            AttributeContainer.SetPosition(NameContainer.X - TopicToEntryXOffset, y + 122);
             AttributeContainer.Relayout();
-            AttributeIconContainer.SetPosition(X + 20, Y + 160);
+            AttributeIconContainer.SetPosition(X + 20, Y + 157);
             AttributeIconContainer.Relayout();
-            SpecialStatContainer.SetPosition(ClassContainer.X, y + 151);
+            SpecialStatContainer.SetPosition(ClassContainer.X, y + 148);
             SpecialStatContainer.Relayout();
             BlessingContainer.SetPosition(X + 400, AttributeContainer.Y);
             BlessingContainer.Relayout();
-            TraceContainer.SetPosition(AttributeContainer.X, y + 285);
+            TraceContainer.SetPosition(AttributeContainer.X, y + 279);
             TraceContainer.Relayout();
             ExtraContainer.SetPosition(ClassContainer.X - TopicToEntryXOffset, TraceContainer.Y);
             ExtraContainer.Relayout();
             RollsContainer.SetPosition(BlessingContainer.X, y + 260);
             RollsContainer.Relayout();
-            TextBuffHintTopic.SetPosition(x + 30, y + 379);
-            TextBuffHintBody.SetPosition(x + 65, y + 379);
+            TextBuffHintTopic.SetPosition(NameContainer.X, y + 375);
+            TextBuffHintBody.SetPosition(TextBuffHintTopic.X + 35, TextBuffHintTopic.Y);
         }
 
         public override void Update(float dt)

--- a/OpenNefia.Content/CharaInfo/SkillsListControl.cs
+++ b/OpenNefia.Content/CharaInfo/SkillsListControl.cs
@@ -362,7 +362,7 @@ namespace OpenNefia.Content.CharaInfo
                 return new SkillsListEntry.Resist(name, desc, power, detail, elementProto);
             }
 
-            foreach (var skillProto in _protos.EnumeratePrototypes<SkillPrototype>().Where(p => ShouldDisplaySkill(p, _charaEntity)))
+            foreach (var skillProto in _skills.EnumerateRegularSkills().Where(p => ShouldDisplaySkill(p, _charaEntity)))
             {
                 var entry = MakeSkillEntry(skillProto);
                 skillEntries.Add(entry);

--- a/OpenNefia.Content/UI/UiFonts.cs
+++ b/OpenNefia.Content/UI/UiFonts.cs
@@ -26,8 +26,8 @@ namespace OpenNefia.Content.UI
         public static readonly FontSpec CharaMakeRerollAttrAmount = new(14, 12, style: FontStyle.Bold);
         public static readonly FontSpec CharaMakeRerollLocked = new(11, 9, color: UiColors.CharaMakeAttrLevelGreat, style: FontStyle.Bold);
 
-        public static readonly FontSpec CharaSheetInfo = new(13, 11, style: FontStyle.Bold);
-        public static readonly FontSpec CharaSheetInfoContent = new(14, 12);
+        public static readonly FontSpec CharaSheetInfo = new(13, 13, style: FontStyle.Bold);
+        public static readonly FontSpec CharaSheetInfoContent = new(14, 14);
         public static readonly FontSpec CharaSheetBuffHintBody = new(13, 12);
         public static readonly FontSpec CharaSheetBuffHintTopic = new(11, 11, style: FontStyle.Bold); // 11 + sizefix * 2
 

--- a/OpenNefia.Content/UI/UiFonts.cs
+++ b/OpenNefia.Content/UI/UiFonts.cs
@@ -28,8 +28,8 @@ namespace OpenNefia.Content.UI
 
         public static readonly FontSpec CharaSheetInfo = new(13, 13, style: FontStyle.Bold);
         public static readonly FontSpec CharaSheetInfoContent = new(14, 14);
-        public static readonly FontSpec CharaSheetBuffHintBody = new(13, 12);
-        public static readonly FontSpec CharaSheetBuffHintTopic = new(11, 11, style: FontStyle.Bold); // 11 + sizefix * 2
+        public static readonly FontSpec CharaSheetBuffHintTopic = new(12, 12, style: FontStyle.Bold); // 11 + sizefix * 2
+        public static readonly FontSpec CharaSheetBuffHintBody = new(12, 12);
 
         public static readonly FontSpec KeyHintBar = new(12, 12, color: UiColors.TextKeyHintBar, bgColor: UiColors.TextBlack);
 


### PR DESCRIPTION
Paddings in CharaInfoSheet and CharaAppearance are replaced with pixel offsets. RaceClass wasn't touched as there are many icons which makes the positions bit of a mess.

For CharaInfoSheet, scaling is taken into consideration but it just don't function well for the time being as the UIScale passed to GraphicsS are locked to 1 somehow. I decided to keep it as-is without making workaround so one day when scaling is sorted out it will function as expected. The same issue is likely the cause for the text clipping you mentioned before.
[code](https://github.com/OpenNefia/OpenNefia/blob/9a27cbed1eade118074157d9dc636d2f54e7c384/OpenNefia.Content/CharaInfo/CharaSheetControl.cs#L405C1-L405C1)
![old_info](https://github.com/OpenNefia/OpenNefia/assets/23335105/8200bd68-f174-4118-bcfb-f716bcf82b51)

For CharaAppearance, I made the choices into switchable lists, which makes me wonder why didn't Noa do this in the first place.
![old_make](https://github.com/OpenNefia/OpenNefia/assets/23335105/7624d986-eef8-43d5-94b9-956b5cb640c0)

This PR also fixes a minor bug that weapon proficiencies are shown twice in the SkillsList.